### PR TITLE
Add Developer Marketing Handbook with modal and standalone page

### DIFF
--- a/astro-site/src/components/DevMarketingConsole.astro
+++ b/astro-site/src/components/DevMarketingConsole.astro
@@ -1,0 +1,979 @@
+---
+// Developer Marketing Console Component
+const commands = {
+  help: {
+    description: 'Available commands',
+    content: `<span class="help-section-title"># Developer Marketing Console Commands</span>
+
+<span class="cmd-name">goals</span>     : What developer marketing is trying to achieve
+<span class="cmd-name">strategy</span>  : How to think about the program
+<span class="cmd-name">journey</span>   : What the developer experience looks like
+<span class="cmd-name">personas</span>  : Who you're talking to
+<span class="cmd-name">messaging</span> : What to say and how to say it
+<span class="cmd-name">campaigns</span> : How to launch developer content
+<span class="cmd-name">content</span>   : How to write for devs
+<span class="cmd-name">community</span> : Where devs hang out
+<span class="cmd-name">metrics</span>   : What to measure
+
+<span class="cmd-name">next</span>      : Navigate to the next section
+<span class="cmd-name">prev</span>      : Navigate to the previous section
+<span class="cmd-name">clear</span>     : Clears the terminal`
+  },
+  goals: {
+    description: 'Developer marketing goals',
+    content: `<span class="terminal-header">goals</span>
+
+Developer marketing builds trust first, pipeline second.
+The work connects your product to how developers actually build and helps that credibility translate into adoption and revenue.
+
+A great developer experience is the foundation. It starts with discoverability, continues through docs, and carries into the product itself. Good documentation shortens time to value and builds confidence that your product can scale with real teams.
+
+Success isn't clicks or vanity metrics. It's measurable engagement that creates product-qualified leads, builds influence across teams, and contributes to both product-led and sales-led growth.
+When developers use your product by choice and advocate for it inside their company, you've done the job right.`
+  },
+  strategy: {
+    description: 'Strategic framework',
+    content: `<span class="terminal-header">strategy</span>
+
+Start with reality, not aspiration.
+Map where your product fits in the developer workflow, then help them do that job faster or with less friction.
+
+Lead with clarity. Explain what it is, what it does, and why it matters.
+If you can do it in a clever or playful way that still feels authentic, that's bonus points.
+
+The best developer marketing respects time, delivers value, and makes something complex feel obvious.`
+  },
+  journey: {
+    description: 'Developer journey stages',
+    content: `<span class="terminal-header">journey</span>
+
+Awareness → Evaluation → Adoption → Advocacy.
+Each stage should connect clearly to the next.
+
+Awareness happens in places developers already spend time: GitHub, Reddit, newsletters, blogs.
+Evaluation happens in your docs, demos, and sandboxes.
+Adoption depends on how fast they reach first success.
+Advocacy is when they start teaching others what they learned from you.`
+  },
+  personas: {
+    description: 'Developer personas',
+    content: `<span class="terminal-header">personas</span>
+
+Buyers: CTO or Engineering Leader, Senior Engineer, Implementation Architect.
+Users: Frontend, Full-stack, App Developer.
+Adjacent: Ops, Product, Design.
+
+Each persona has different pain points and goals.
+CTOs and Engineering Leaders care about governance and ROI.
+Senior Engineers look for performance, flexibility, and code quality.
+Implementation Architects focus on how well a tool integrates and scales.
+Write for what each person owns, not what you wish they cared about.`
+  },
+  messaging: {
+    description: 'Messaging framework',
+    content: `<span class="terminal-header">messaging</span>
+
+Be clear first. Be clever only if it helps.
+Good developer messaging is specific, practical, and rooted in how people actually build.
+
+Clarity earns trust, but a bit of personality makes it stick.
+The goal isn't to sound like marketing. It's to communicate something real that developers recognize and care about.
+
+Build around three pillars:
+  <span class="terminal-bullet">•</span> <strong>Speed:</strong> faster builds, fewer tickets
+  <span class="terminal-bullet">•</span> <strong>Efficiency:</strong> consolidated stack, lower maintenance
+  <span class="terminal-bullet">•</span> <strong>Control:</strong> safe scale, long-term confidence
+
+If you can back it with code, data, or proof, keep it.
+If it only sounds good, cut it.`
+  },
+  campaigns: {
+    description: 'Campaign strategies',
+    content: `<span class="terminal-header">campaigns</span>
+
+Treat campaigns like product launches.
+Plan, ship, measure, repeat.
+
+Each campaign should answer three questions:
+  <span class="terminal-bullet">•</span> What developer problem are we solving?
+  <span class="terminal-bullet">•</span> What proof are we showing?
+  <span class="terminal-bullet">•</span> What happens next?
+
+Make it easy for developers to try, test, or share.
+Run retros on every launch and capture what worked, what didn't, and what to change next time. Always learn from what you launch.`
+  },
+  content: {
+    description: 'Content creation guide',
+    content: `<span class="terminal-header">content</span>
+
+Write with clarity and intention. Every piece should help developers build faster, learn something new, or solve a real problem.
+
+Strong content earns attention because it's useful. Show working examples, explain tradeoffs, and include visuals or code where it helps understanding. If it doesn't teach or demonstrate something real, it doesn't belong.
+
+<strong>Core content types</strong>
+  <span class="terminal-bullet">•</span> <strong>Blog posts:</strong> tutorials, technical breakdowns, or opinionated takes grounded in experience.
+  <span class="terminal-bullet">•</span> <strong>Guides and tutorials:</strong> step-by-step instructions that lead to a working result.
+  <span class="terminal-bullet">•</span> <strong>Integration or workflow content:</strong> explain how tools connect and where they fit in the stack.`
+  },
+  community: {
+    description: 'Community platforms',
+    content: `<span class="terminal-header">community</span>
+
+Reddit. GitHub. Discord. Docs.
+Join conversations, don't start pitches.
+
+Be helpful. Add context. Share working examples.
+When your content becomes the answer people link to, you've earned credibility.`
+  },
+  metrics: {
+    description: 'Key metrics',
+    content: `<span class="terminal-header">metrics</span>
+
+Measure what proves adoption, not awareness.
+Track outcomes, not outputs.
+
+Signals that matter:
+  <span class="terminal-bullet">•</span> Time to first success
+  <span class="terminal-bullet">•</span> API usage or active developer growth
+  <span class="terminal-bullet">•</span> Dev-influenced revenue
+  <span class="terminal-bullet">•</span> Community participation
+
+If it doesn't show developer impact, it's just noise.`
+  },
+};
+---
+
+<div id="devConsoleButton" class="dev-console-button">
+  Handbook
+</div>
+
+<div id="devConsoleOverlay" class="dev-console-overlay">
+  <div class="handbook-modal">
+    <div class="handbook-header">
+      <span class="handbook-title">Developer Marketing Handbook</span>
+      <button id="closeConsole" class="handbook-close" aria-label="Close handbook">×</button>
+    </div>
+
+    <div class="handbook-body">
+      <nav class="handbook-nav">
+        <ul class="nav-links">
+          <li><a href="#goals" class="nav-link">Goals</a></li>
+          <li><a href="#strategy" class="nav-link">Strategy</a></li>
+          <li><a href="#journey" class="nav-link">Journey</a></li>
+          <li><a href="#personas" class="nav-link">Personas</a></li>
+          <li><a href="#messaging" class="nav-link">Messaging</a></li>
+          <li><a href="#campaigns" class="nav-link">Campaigns</a></li>
+          <li><a href="#content" class="nav-link">Content</a></li>
+          <li><a href="#community" class="nav-link">Community</a></li>
+          <li><a href="#metrics" class="nav-link">Metrics</a></li>
+          <li><a href="https://lucasstahl.com/gems" class="nav-link nav-link-external" target="_blank">Gems</a></li>
+        </ul>
+      </nav>
+
+      <main class="handbook-content">
+        <section id="goals" class="handbook-section">
+          <h2>Goals</h2>
+          <p>Developer marketing builds trust first, pipeline second.<br/>
+          The work connects your product to how developers actually build and helps that credibility translate into adoption and revenue.</p>
+
+          <p>A great developer experience is the foundation. It starts with discoverability, continues through docs, and carries into the product itself. Good documentation shortens time to value and builds confidence that your product can scale with real teams.</p>
+
+          <p>Success isn't clicks or vanity metrics. It's measurable engagement that creates product-qualified leads, builds influence across teams, and contributes to both product-led and sales-led growth.<br/>
+          When developers use your product by choice and advocate for it inside their company, you've done the job right.</p>
+        </section>
+
+        <section id="strategy" class="handbook-section">
+          <h2>Strategy</h2>
+          <p>Start with reality, not aspiration.<br/>
+          Map where your product fits in the developer workflow, then help them do that job faster or with less friction.</p>
+
+          <p>Lead with clarity. Explain what it is, what it does, and why it matters.<br/>
+          If you can do it in a clever or playful way that still feels authentic, that's bonus points.</p>
+
+          <p>The best developer marketing respects time, delivers value, and makes something complex feel obvious.</p>
+        </section>
+
+        <section id="journey" class="handbook-section">
+          <h2>Journey</h2>
+          <p><strong>Awareness → Evaluation → Adoption → Advocacy.</strong><br/>
+          Each stage should connect clearly to the next.</p>
+
+          <p><strong>Awareness</strong> happens in places developers already spend time: GitHub, Reddit, newsletters, blogs.<br/>
+          <strong>Evaluation</strong> happens in your docs, demos, and sandboxes.<br/>
+          <strong>Adoption</strong> depends on how fast they reach first success.<br/>
+          <strong>Advocacy</strong> is when they start teaching others what they learned from you.</p>
+        </section>
+
+        <section id="personas" class="handbook-section">
+          <h2>Personas</h2>
+          <p><strong>Buyers:</strong> CTO or Engineering Leader, Senior Engineer, Implementation Architect.<br/>
+          <strong>Users:</strong> Frontend, Full-stack, App Developer.<br/>
+          <strong>Adjacent:</strong> Ops, Product, Design.</p>
+
+          <p>Each persona has different pain points and goals.<br/>
+          CTOs and Engineering Leaders care about governance and ROI.<br/>
+          Senior Engineers look for performance, flexibility, and code quality.<br/>
+          Implementation Architects focus on how well a tool integrates and scales.<br/>
+          Write for what each person owns, not what you wish they cared about.</p>
+        </section>
+
+        <section id="messaging" class="handbook-section">
+          <h2>Messaging</h2>
+          <p>Be clear first. Be clever only if it helps.<br/>
+          Good developer messaging is specific, practical, and rooted in how people actually build.</p>
+
+          <p>Clarity earns trust, but a bit of personality makes it stick.<br/>
+          The goal isn't to sound like marketing. It's to communicate something real that developers recognize and care about.</p>
+
+          <h3>Build around three pillars:</h3>
+          <ul>
+            <li><strong>Speed:</strong> faster builds, fewer tickets</li>
+            <li><strong>Efficiency:</strong> consolidated stack, lower maintenance</li>
+            <li><strong>Control:</strong> safe scale, long-term confidence</li>
+          </ul>
+
+          <p>If you can back it with code, data, or proof, keep it.<br/>
+          If it only sounds good, cut it.</p>
+        </section>
+
+        <section id="campaigns" class="handbook-section">
+          <h2>Campaigns</h2>
+          <p>Treat campaigns like product launches.<br/>
+          Plan, ship, measure, repeat.</p>
+
+          <h3>Each campaign should answer three questions:</h3>
+          <ul>
+            <li>What developer problem are we solving?</li>
+            <li>What proof are we showing?</li>
+            <li>What happens next?</li>
+          </ul>
+
+          <p>Make it easy for developers to try, test, or share.<br/>
+          Run retros on every launch and capture what worked, what didn't, and what to change next time. Always learn from what you launch.</p>
+        </section>
+
+        <section id="content" class="handbook-section">
+          <h2>Content</h2>
+          <p>Write with clarity and intention. Every piece should help developers build faster, learn something new, or solve a real problem.</p>
+
+          <p>Strong content earns attention because it's useful. Show working examples, explain tradeoffs, and include visuals or code where it helps understanding. If it doesn't teach or demonstrate something real, it doesn't belong.</p>
+
+          <h3>Core content types</h3>
+          <ul>
+            <li><strong>Blog posts:</strong> tutorials, technical breakdowns, or opinionated takes grounded in experience.</li>
+            <li><strong>Guides and tutorials:</strong> step-by-step instructions that lead to a working result.</li>
+            <li><strong>Integration or workflow content:</strong> explain how tools connect and where they fit in a developer's process.</li>
+            <li><strong>Technical guides and code examples:</strong> deeper material for experienced readers who want implementation detail.</li>
+            <li><strong>Explainer or glossary content:</strong> clear, factual definitions written to answer specific questions directly.</li>
+            <li><strong>Video or live sessions:</strong> demos, interviews, or walkthroughs that show real workflows.</li>
+            <li><strong>Research and surveys:</strong> reports or insights that help developers understand the state of their field.</li>
+          </ul>
+
+          <h3>Content strategy buckets</h3>
+          <ol>
+            <li><strong>Awareness</strong> — ideas and insights that start conversations.</li>
+            <li><strong>Acquisition</strong> — content that helps developers discover your product or approach through practical problem-solving.</li>
+            <li><strong>Enablement</strong> — materials that help users get more value from what they already use.</li>
+            <li><strong>Conversion</strong> — content that helps teams make confident decisions about adoption or scale.</li>
+          </ol>
+
+          <p>Each piece should fit into one of these buckets and serve a clear purpose. Awareness earns attention. Acquisition builds trust. Enablement drives success. Conversion turns success into growth.</p>
+
+          <p>Clarity is the standard. Use it to earn credibility.</p>
+        </section>
+
+        <section id="community" class="handbook-section">
+          <h2>Community</h2>
+          <p>Reddit. GitHub. Discord. Slack. YouTube and other social platforms.<br/>
+          Join conversations, don't start pitches.</p>
+
+          <p>Be helpful. Add context. Share working examples.<br/>
+          When your content becomes the answer people link to, you've earned credibility.</p>
+        </section>
+
+        <section id="metrics" class="handbook-section">
+          <h2>Metrics</h2>
+          <p>Measure adoption and revenue, not reach.<br/>
+          Awareness is useful, but only if it drives activation or expansion.</p>
+
+          <p>Focus on signals that show impact:</p>
+          <ul>
+            <li>Product or API usage</li>
+            <li>Time to first success</li>
+            <li>Product-qualified leads</li>
+            <li>Developer-influenced revenue</li>
+            <li>Retention and repeat engagement</li>
+          </ul>
+
+          <p>The goal is simple: prove that developer trust turns into growth.</p>
+        </section>
+
+        <section class="handbook-cta">
+          <div class="cta-content">
+            <h3>Need more resources?</h3>
+            <p>Check out my curated collection of developer marketing tools, newsletters, and resources.</p>
+            <a href="https://lucasstahl.com/gems" class="cta-button" target="_blank">
+              View Gems →
+            </a>
+          </div>
+        </section>
+      </main>
+    </div>
+  </div>
+</div>
+
+<style>
+  .dev-console-button {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    background: #1a1a1a;
+    color: #c3e88d;
+    padding: 12px 24px;
+    border-radius: 8px;
+    font-family: 'Inter', sans-serif;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    z-index: 999;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    transition: all 0.3s ease;
+    border: 1px solid #c3e88d;
+  }
+
+  .dev-console-button:hover {
+    background: #2a2a2a;
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px rgba(195, 232, 141, 0.3);
+  }
+
+  .dev-console-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0);
+    z-index: 1000;
+    transition: all 0.3s ease;
+    pointer-events: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+  }
+
+  .dev-console-overlay.active {
+    background: rgba(0, 0, 0, 0.8);
+    pointer-events: auto;
+  }
+
+  .handbook-modal {
+    width: 100%;
+    max-width: 1200px;
+    height: 90vh;
+    background: #1a1a1a;
+    border: 2px solid #82aaff;
+    border-radius: 8px;
+    display: grid;
+    grid-template-rows: auto 1fr;
+    opacity: 0;
+    transform: scale(0.95);
+    transition: all 0.3s ease;
+    box-shadow: 0 20px 60px rgba(130, 170, 255, 0.3), 0 0 0 1px rgba(130, 170, 255, 0.1);
+    font-family: 'Fira Code', 'Courier New', monospace;
+  }
+
+  .dev-console-overlay.active .handbook-modal {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  .handbook-header {
+    padding: 16px 20px;
+    background: #0d0d0d;
+    border-bottom: 1px solid #333;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: relative;
+  }
+
+  .handbook-header::before {
+    content: '';
+    position: absolute;
+    left: 20px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: #ff5f56;
+    box-shadow: 20px 0 0 #ffbd2e, 40px 0 0 #27c93f;
+  }
+
+  .handbook-title {
+    color: #c3e88d;
+    font-family: 'Fira Code', monospace;
+    font-size: 14px;
+    font-weight: 600;
+    margin-left: 60px;
+    letter-spacing: 0.5px;
+  }
+
+  .handbook-title::before {
+    content: '> ';
+    color: #82aaff;
+  }
+
+  .handbook-close {
+    background: none;
+    border: none;
+    color: #82aaff;
+    font-size: 32px;
+    cursor: pointer;
+    padding: 0;
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: color 0.2s;
+    line-height: 1;
+  }
+
+  .handbook-close:hover {
+    color: #ff6b6b;
+  }
+
+  .handbook-body {
+    display: grid;
+    grid-template-columns: 240px 1fr;
+    overflow: hidden;
+  }
+
+  /* Handbook Navigation */
+  .handbook-nav {
+    background: #151515;
+    border-right: 1px solid #333;
+    overflow-y: auto;
+    padding: 20px 16px;
+  }
+
+  .nav-links {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .nav-links li {
+    margin-bottom: 4px;
+  }
+
+  .nav-link {
+    display: block;
+    padding: 10px 12px;
+    color: #888;
+    text-decoration: none;
+    border-radius: 4px;
+    transition: all 0.2s;
+    font-size: 13px;
+    font-family: 'Fira Code', monospace;
+    position: relative;
+  }
+
+  .nav-link::before {
+    content: '$ ';
+    color: #82aaff;
+    opacity: 0;
+    transition: opacity 0.2s;
+  }
+
+  .nav-link:hover,
+  .nav-link.active {
+    color: #c3e88d;
+    background: rgba(195, 232, 141, 0.1);
+  }
+
+  .nav-link:hover::before,
+  .nav-link.active::before {
+    opacity: 1;
+  }
+
+  .nav-link-external {
+    margin-top: 8px;
+    padding-top: 12px;
+    border-top: 1px solid #333;
+  }
+
+  .nav-link-external::after {
+    content: ' ↗';
+    font-size: 12px;
+    opacity: 0.7;
+  }
+
+  /* Handbook Content */
+  .handbook-content {
+    overflow-y: auto;
+    padding: 32px 40px;
+    background: #1a1a1a;
+  }
+
+  .handbook-section {
+    margin-bottom: 48px;
+    scroll-margin-top: 20px;
+  }
+
+  .handbook-section h2 {
+    font-size: 20px;
+    font-weight: 600;
+    color: #82aaff;
+    margin: 0 0 20px 0;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #333;
+    font-family: 'Fira Code', monospace;
+    letter-spacing: 0.5px;
+  }
+
+  .handbook-section h2::before {
+    content: '> ';
+    color: #82aaff;
+    margin-right: 10px;
+  }
+
+  .handbook-section h3 {
+    font-size: 16px;
+    font-weight: 600;
+    color: #82aaff;
+    margin: 24px 0 12px 0;
+    font-family: 'Fira Code', monospace;
+  }
+
+  .handbook-section h3::before {
+    content: '>> ';
+    color: #82aaff;
+    margin-right: 8px;
+  }
+
+  .handbook-section p {
+    line-height: 1.8;
+    margin-bottom: 18px;
+    color: #d0d0d0;
+    font-size: 14px;
+    font-family: 'Fira Code', monospace;
+  }
+
+  .handbook-section ul,
+  .handbook-section ol {
+    margin: 16px 0 24px 0;
+    line-height: 1.8;
+    padding-left: 0;
+  }
+
+  .handbook-section ul {
+    list-style: none;
+  }
+
+  .handbook-section ol {
+    list-style: none;
+    counter-reset: item;
+  }
+
+  .handbook-section li {
+    margin-bottom: 10px;
+    color: #d0d0d0;
+    font-size: 14px;
+    font-family: 'Fira Code', monospace;
+    padding-left: 24px;
+    position: relative;
+  }
+
+  .handbook-section ul li::before {
+    content: '•';
+    color: #82aaff;
+    position: absolute;
+    left: 8px;
+  }
+
+  .handbook-section ol li {
+    counter-increment: item;
+  }
+
+  .handbook-section ol li::before {
+    content: counter(item) ". ";
+    color: #82aaff;
+    position: absolute;
+    left: 0;
+    font-weight: 600;
+  }
+
+  .handbook-section strong {
+    color: #c3e88d;
+    font-weight: 600;
+  }
+
+  /* CTA Section */
+  .handbook-cta {
+    margin-top: 48px;
+    padding: 32px;
+    background: linear-gradient(135deg, rgba(130, 170, 255, 0.1) 0%, rgba(195, 232, 141, 0.1) 100%);
+    border: 1px solid rgba(130, 170, 255, 0.3);
+    border-radius: 8px;
+    text-align: center;
+  }
+
+  .cta-content h3 {
+    font-size: 20px;
+    font-weight: 600;
+    color: #82aaff;
+    margin: 0 0 12px 0;
+    font-family: 'Fira Code', monospace;
+  }
+
+  .cta-content h3::before {
+    content: '> ';
+    color: #82aaff;
+    margin-right: 8px;
+  }
+
+  .cta-content p {
+    font-size: 14px;
+    color: #d0d0d0;
+    margin: 0 0 24px 0;
+    font-family: 'Fira Code', monospace;
+    line-height: 1.6;
+  }
+
+  .cta-button {
+    display: inline-block;
+    padding: 12px 28px;
+    background: #82aaff;
+    color: #0d0d0d;
+    text-decoration: none;
+    border-radius: 6px;
+    font-family: 'Fira Code', monospace;
+    font-size: 14px;
+    font-weight: 600;
+    transition: all 0.3s ease;
+    border: 2px solid #82aaff;
+  }
+
+  .cta-button:hover {
+    background: transparent;
+    color: #82aaff;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(130, 170, 255, 0.3);
+  }
+
+  /* Scrollbar styling */
+  .handbook-nav::-webkit-scrollbar,
+  .handbook-content::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  .handbook-nav::-webkit-scrollbar-track,
+  .handbook-content::-webkit-scrollbar-track {
+    background: #0d0d0d;
+  }
+
+  .handbook-nav::-webkit-scrollbar-thumb,
+  .handbook-content::-webkit-scrollbar-thumb {
+    background: #333;
+    border-radius: 4px;
+  }
+
+  .handbook-nav::-webkit-scrollbar-thumb:hover,
+  .handbook-content::-webkit-scrollbar-thumb:hover {
+    background: #444;
+  }
+
+  /* Responsive */
+  @media (max-width: 968px) {
+    .handbook-modal {
+      max-width: 100%;
+      height: 100vh;
+      border-radius: 0;
+    }
+
+    .handbook-body {
+      grid-template-columns: 1fr;
+      grid-template-rows: auto 1fr;
+    }
+
+    .handbook-nav {
+      border-right: none;
+      border-bottom: 1px solid #333;
+      padding: 16px;
+      overflow-x: auto;
+      overflow-y: hidden;
+    }
+
+    .nav-links {
+      display: flex;
+      flex-wrap: nowrap;
+      gap: 8px;
+      white-space: nowrap;
+    }
+
+    .nav-links li {
+      margin-bottom: 0;
+      flex-shrink: 0;
+    }
+
+    .nav-link {
+      padding: 8px 16px;
+      font-size: 12px;
+    }
+
+    .handbook-content {
+      padding: 24px 20px;
+    }
+
+    .handbook-section h2 {
+      font-size: 18px;
+    }
+
+    .handbook-section h3 {
+      font-size: 15px;
+    }
+
+    .handbook-section p,
+    .handbook-section li {
+      font-size: 13px;
+    }
+
+    .cta-content h3 {
+      font-size: 18px;
+    }
+
+    .cta-content p {
+      font-size: 13px;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .dev-console-button {
+      bottom: 20px;
+      right: 20px;
+      padding: 10px 20px;
+      font-size: 13px;
+    }
+
+    .dev-console-overlay {
+      padding: 0;
+    }
+
+    .handbook-modal {
+      border: none;
+      border-radius: 0;
+    }
+
+    .handbook-header {
+      padding: 14px 16px;
+    }
+
+    .handbook-header::before {
+      left: 16px;
+      width: 10px;
+      height: 10px;
+      box-shadow: 18px 0 0 #ffbd2e, 36px 0 0 #27c93f;
+    }
+
+    .handbook-title {
+      font-size: 13px;
+      margin-left: 50px;
+    }
+
+    .handbook-close {
+      font-size: 28px;
+      width: 32px;
+      height: 32px;
+    }
+
+    .handbook-content {
+      padding: 20px 16px;
+    }
+
+    .handbook-section {
+      margin-bottom: 36px;
+    }
+
+    .handbook-cta {
+      padding: 24px 20px;
+      margin-top: 36px;
+    }
+
+    .cta-content h3 {
+      font-size: 18px;
+    }
+
+    .cta-content p {
+      font-size: 13px;
+      margin-bottom: 20px;
+    }
+
+    .cta-button {
+      padding: 10px 24px;
+      font-size: 13px;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .handbook-header::before {
+      display: none;
+    }
+
+    .handbook-title {
+      margin-left: 0;
+      font-size: 12px;
+    }
+
+    .handbook-content {
+      padding: 16px 12px;
+    }
+
+    .handbook-section h2 {
+      font-size: 16px;
+    }
+
+    .handbook-section h3 {
+      font-size: 14px;
+    }
+
+    .handbook-section p,
+    .handbook-section li {
+      font-size: 12px;
+      line-height: 1.7;
+    }
+
+    .handbook-cta {
+      padding: 20px 16px;
+      margin-top: 32px;
+    }
+
+    .cta-content h3 {
+      font-size: 16px;
+    }
+
+    .cta-content p {
+      font-size: 12px;
+      line-height: 1.7;
+      margin-bottom: 18px;
+    }
+
+    .cta-button {
+      padding: 10px 20px;
+      font-size: 12px;
+    }
+  }
+</style>
+
+<script>
+  const button = document.getElementById('devConsoleButton');
+  const overlay = document.getElementById('devConsoleOverlay');
+  const closeButton = document.getElementById('closeConsole');
+  const navLinks = document.querySelectorAll('.nav-link');
+  const sections = document.querySelectorAll('.handbook-section');
+
+  function openHandbook() {
+    overlay.classList.add('active');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeHandbook() {
+    overlay.classList.remove('active');
+    document.body.style.overflow = '';
+  }
+
+  // Open/close handlers
+  button.addEventListener('click', openHandbook);
+  closeButton.addEventListener('click', closeHandbook);
+
+  // Close on clicking overlay background
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) {
+      closeHandbook();
+    }
+  });
+
+  // Keyboard navigation
+  document.addEventListener('keydown', (e) => {
+    if (!overlay.classList.contains('active')) return;
+
+    if (e.key === 'Escape') {
+      closeHandbook();
+    }
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      // Find currently active nav link
+      const activeLink = document.querySelector('.nav-link.active');
+      if (activeLink) {
+        const nextLi = activeLink.parentElement.nextElementSibling;
+        if (nextLi) {
+          const nextLink = nextLi.querySelector('.nav-link');
+          if (nextLink) {
+            nextLink.click();
+          }
+        }
+      } else {
+        // If no active link, go to first section
+        const firstLink = document.querySelector('.nav-link');
+        if (firstLink) firstLink.click();
+      }
+    }
+
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      // Find currently active nav link
+      const activeLink = document.querySelector('.nav-link.active');
+      if (activeLink) {
+        const prevLi = activeLink.parentElement.previousElementSibling;
+        if (prevLi) {
+          const prevLink = prevLi.querySelector('.nav-link');
+          if (prevLink) {
+            prevLink.click();
+          }
+        }
+      }
+    }
+  });
+
+  // Smooth scroll for nav links
+  navLinks.forEach(link => {
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      const targetId = link.getAttribute('href').substring(1);
+      const targetSection = document.getElementById(targetId);
+
+      if (targetSection) {
+        targetSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+        // Update active state
+        navLinks.forEach(l => l.classList.remove('active'));
+        link.classList.add('active');
+      }
+    });
+  });
+
+  // Highlight active section on scroll
+  const handbookContent = document.querySelector('.handbook-content');
+
+  if (handbookContent) {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          const id = entry.target.getAttribute('id');
+          navLinks.forEach(link => {
+            link.classList.remove('active');
+            if (link.getAttribute('href') === `#${id}`) {
+              link.classList.add('active');
+            }
+          });
+        }
+      });
+    }, { root: handbookContent, threshold: 0.5 });
+
+    sections.forEach(section => observer.observe(section));
+  }
+</script>

--- a/astro-site/src/components/Footer.astro
+++ b/astro-site/src/components/Footer.astro
@@ -4,6 +4,9 @@
 
 <footer class="footer">
     <div class="footer-content">
+        <div class="footer-links">
+            <a href="/handbook" class="footer-link">Developer Marketing Handbook</a>
+        </div>
         <div class="footer-social">
             <a href="https://twitter.com/LucasStahl11" target="_blank" rel="noopener noreferrer" aria-label="Twitter">
                 <i class="fa-brands fa-x-twitter"></i>
@@ -26,6 +29,59 @@
         <p class="footer-copyright">© 2025 Luke Stahl. Built with code and curiosity.</p>
     </div>
 </footer>
+
+<style>
+    .footer-links {
+        margin: 0 0 12px 0;
+    }
+
+    .footer-link {
+        color: #888;
+        text-decoration: none;
+        font-size: 14px;
+        font-family: 'Inter', sans-serif;
+        transition: all 0.3s ease;
+        padding: 4px 12px;
+        border: 1px solid #333;
+        border-radius: 4px;
+        display: inline-block;
+        position: relative;
+        animation: subtle-glow 3s ease-in-out infinite;
+    }
+
+    .footer-link:hover {
+        color: #c3e88d;
+        border-color: #c3e88d;
+        text-decoration: none;
+        box-shadow: 0 0 10px rgba(195, 232, 141, 0.3);
+        animation: none;
+    }
+
+    @keyframes subtle-glow {
+        0%, 100% {
+            box-shadow: 0 0 5px rgba(195, 232, 141, 0.1);
+        }
+        50% {
+            box-shadow: 0 0 8px rgba(195, 232, 141, 0.2);
+        }
+    }
+
+    @media (max-width: 768px) {
+        .footer-link {
+            font-size: 13px;
+        }
+    }
+
+    @media (max-width: 480px) {
+        .footer-links {
+            margin: 0 0 10px 0;
+        }
+
+        .footer-link {
+            font-size: 12px;
+        }
+    }
+</style>
 
 <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
     integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"

--- a/astro-site/src/layouts/Layout.astro
+++ b/astro-site/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import Navbar from '../components/Navbar.astro';
 import Footer from '../components/Footer.astro';
 import PostHog from '../components/posthog.astro';
+import DevMarketingConsole from '../components/DevMarketingConsole.astro';
 
 interface Props {
 	title: string;
@@ -11,6 +12,7 @@ interface Props {
 	ogImage?: string;
 	canonicalUrl?: string;
 	additionalCss?: string[];
+	hideHandbookButton?: boolean;
 }
 
 const {
@@ -20,7 +22,8 @@ const {
 	ogDescription = "Developer marketer and web developer with a passion for building and optimizing for the web, bridging the gap between marketing strategy and technical implementation.",
 	ogImage = "https://lucasstahl.com/assets/images/devMktg_og.png",
 	canonicalUrl = "https://lucasstahl.com",
-	additionalCss = []
+	additionalCss = [],
+	hideHandbookButton = false
 } = Astro.props;
 ---
 
@@ -89,5 +92,6 @@ const {
 	<Navbar />
 	<slot />
 	<Footer />
+	{!hideHandbookButton && <DevMarketingConsole />}
 </body>
 </html>

--- a/astro-site/src/pages/handbook.astro
+++ b/astro-site/src/pages/handbook.astro
@@ -1,0 +1,650 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout
+	title="Developer Marketing Handbook | Luke Stahl"
+	description="A handbook for developer marketing that covers goals, strategy, journey, personas, messaging, campaigns, content, community, and metrics."
+	ogTitle="Developer Marketing Handbook | Luke Stahl"
+	ogDescription="A comprehensive guide to developer marketing covering strategy, messaging, content creation, and metrics that matter."
+	canonicalUrl="https://lucasstahl.com/handbook"
+	hideHandbookButton={true}
+>
+	<div class="handbook-page-container">
+		<div class="handbook-page-header">
+			<div class="handbook-page-header-content">
+				<h1 class="handbook-page-title">Developer Marketing Handbook</h1>
+			</div>
+		</div>
+
+		<div class="handbook-page-body">
+			<nav class="handbook-page-nav">
+				<ul class="nav-links">
+					<li><a href="#goals" class="nav-link">Goals</a></li>
+					<li><a href="#strategy" class="nav-link">Strategy</a></li>
+					<li><a href="#journey" class="nav-link">Journey</a></li>
+					<li><a href="#personas" class="nav-link">Personas</a></li>
+					<li><a href="#messaging" class="nav-link">Messaging</a></li>
+					<li><a href="#campaigns" class="nav-link">Campaigns</a></li>
+					<li><a href="#content" class="nav-link">Content</a></li>
+					<li><a href="#community" class="nav-link">Community</a></li>
+					<li><a href="#metrics" class="nav-link">Metrics</a></li>
+					<li><a href="https://lucasstahl.com/gems" class="nav-link nav-link-external" target="_blank">Gems</a></li>
+				</ul>
+			</nav>
+
+			<main class="handbook-page-content">
+				<section id="goals" class="handbook-section">
+					<h2>Goals</h2>
+					<p>Developer marketing builds trust first, pipeline second.<br/>
+					The work connects your product to how developers actually build and helps that credibility translate into adoption and revenue.</p>
+
+					<p>A great developer experience is the foundation. It starts with discoverability, continues through docs, and carries into the product itself. Good documentation shortens time to value and builds confidence that your product can scale with real teams.</p>
+
+					<p>Success isn't clicks or vanity metrics. It's measurable engagement that creates product-qualified leads, builds influence across teams, and contributes to both product-led and sales-led growth.<br/>
+					When developers use your product by choice and advocate for it inside their company, you've done the job right.</p>
+				</section>
+
+				<section id="strategy" class="handbook-section">
+					<h2>Strategy</h2>
+					<p>Start with reality, not aspiration.<br/>
+					Map where your product fits in the developer workflow, then help them do that job faster or with less friction.</p>
+
+					<p>Lead with clarity. Explain what it is, what it does, and why it matters.<br/>
+					If you can do it in a clever or playful way that still feels authentic, that's bonus points.</p>
+
+					<p>The best developer marketing respects time, delivers value, and makes something complex feel obvious.</p>
+				</section>
+
+				<section id="journey" class="handbook-section">
+					<h2>Journey</h2>
+					<p><strong>Awareness → Evaluation → Adoption → Advocacy.</strong><br/>
+					Each stage should connect clearly to the next.</p>
+
+					<p><strong>Awareness</strong> happens in places developers already spend time: GitHub, Reddit, newsletters, blogs.<br/>
+					<strong>Evaluation</strong> happens in your docs, demos, and sandboxes.<br/>
+					<strong>Adoption</strong> depends on how fast they reach first success.<br/>
+					<strong>Advocacy</strong> is when they start teaching others what they learned from you.</p>
+				</section>
+
+				<section id="personas" class="handbook-section">
+					<h2>Personas</h2>
+					<p><strong>Buyers:</strong> CTO or Engineering Leader, Senior Engineer, Implementation Architect.<br/>
+					<strong>Users:</strong> Frontend, Full-stack, App Developer.<br/>
+					<strong>Adjacent:</strong> Ops, Product, Design.</p>
+
+					<p>Each persona has different pain points and goals.<br/>
+					CTOs and Engineering Leaders care about governance and ROI.<br/>
+					Senior Engineers look for performance, flexibility, and code quality.<br/>
+					Implementation Architects focus on how well a tool integrates and scales.<br/>
+					Write for what each person owns, not what you wish they cared about.</p>
+				</section>
+
+				<section id="messaging" class="handbook-section">
+					<h2>Messaging</h2>
+					<p>Be clear first. Be clever only if it helps.<br/>
+					Good developer messaging is specific, practical, and rooted in how people actually build.</p>
+
+					<p>Clarity earns trust, but a bit of personality makes it stick.<br/>
+					The goal isn't to sound like marketing. It's to communicate something real that developers recognize and care about.</p>
+
+					<h3>Build around three pillars:</h3>
+					<ul>
+						<li><strong>Speed:</strong> faster builds, fewer tickets</li>
+						<li><strong>Efficiency:</strong> consolidated stack, lower maintenance</li>
+						<li><strong>Control:</strong> safe scale, long-term confidence</li>
+					</ul>
+
+					<p>If you can back it with code, data, or proof, keep it.<br/>
+					If it only sounds good, cut it.</p>
+				</section>
+
+				<section id="campaigns" class="handbook-section">
+					<h2>Campaigns</h2>
+					<p>Treat campaigns like product launches.<br/>
+					Plan, ship, measure, repeat.</p>
+
+					<h3>Each campaign should answer three questions:</h3>
+					<ul>
+						<li>What developer problem are we solving?</li>
+						<li>What proof are we showing?</li>
+						<li>What happens next?</li>
+					</ul>
+
+					<p>Make it easy for developers to try, test, or share.<br/>
+					Run retros on every launch and capture what worked, what didn't, and what to change next time. Always learn from what you launch.</p>
+				</section>
+
+				<section id="content" class="handbook-section">
+					<h2>Content</h2>
+					<p>Write with clarity and intention. Every piece should help developers build faster, learn something new, or solve a real problem.</p>
+
+					<p>Strong content earns attention because it's useful. Show working examples, explain tradeoffs, and include visuals or code where it helps understanding. If it doesn't teach or demonstrate something real, it doesn't belong.</p>
+
+					<h3>Core content types</h3>
+					<ul>
+						<li><strong>Blog posts:</strong> tutorials, technical breakdowns, or opinionated takes grounded in experience.</li>
+						<li><strong>Guides and tutorials:</strong> step-by-step instructions that lead to a working result.</li>
+						<li><strong>Integration or workflow content:</strong> explain how tools connect and where they fit in a developer's process.</li>
+						<li><strong>Technical guides and code examples:</strong> deeper material for experienced readers who want implementation detail.</li>
+						<li><strong>Explainer or glossary content:</strong> clear, factual definitions written to answer specific questions directly.</li>
+						<li><strong>Video or live sessions:</strong> demos, interviews, or walkthroughs that show real workflows.</li>
+						<li><strong>Research and surveys:</strong> reports or insights that help developers understand the state of their field.</li>
+					</ul>
+
+					<h3>Content strategy buckets</h3>
+					<ol>
+						<li><strong>Awareness</strong> — ideas and insights that start conversations.</li>
+						<li><strong>Acquisition</strong> — content that helps developers discover your product or approach through practical problem-solving.</li>
+						<li><strong>Enablement</strong> — materials that help users get more value from what they already use.</li>
+						<li><strong>Conversion</strong> — content that helps teams make confident decisions about adoption or scale.</li>
+					</ol>
+
+					<p>Each piece should fit into one of these buckets and serve a clear purpose. Awareness earns attention. Acquisition builds trust. Enablement drives success. Conversion turns success into growth.</p>
+
+					<p>Clarity is the standard. Use it to earn credibility.</p>
+				</section>
+
+				<section id="community" class="handbook-section">
+					<h2>Community</h2>
+					<p>Reddit. GitHub. Discord. Slack. YouTube and other social platforms.<br/>
+					Join conversations, don't start pitches.</p>
+
+					<p>Be helpful. Add context. Share working examples.<br/>
+					When your content becomes the answer people link to, you've earned credibility.</p>
+				</section>
+
+				<section id="metrics" class="handbook-section">
+					<h2>Metrics</h2>
+					<p>Measure adoption and revenue, not reach.<br/>
+					Awareness is useful, but only if it drives activation or expansion.</p>
+
+					<p>Focus on signals that show impact:</p>
+					<ul>
+						<li>Product or API usage</li>
+						<li>Time to first success</li>
+						<li>Product-qualified leads</li>
+						<li>Developer-influenced revenue</li>
+						<li>Retention and repeat engagement</li>
+					</ul>
+
+					<p>The goal is simple: prove that developer trust turns into growth.</p>
+				</section>
+
+				<section class="handbook-cta">
+					<div class="cta-content">
+						<h3>Need more resources?</h3>
+						<p>Check out my curated collection of developer marketing tools, newsletters, and resources.</p>
+						<a href="https://lucasstahl.com/gems" class="cta-button">
+							View Gems →
+						</a>
+					</div>
+				</section>
+			</main>
+		</div>
+	</div>
+</Layout>
+
+<style>
+	.handbook-page-container {
+		min-height: 100vh;
+		background: #1a1a1a;
+		color: #e4e4e7;
+	}
+
+	.handbook-page-header {
+		background: #0d0d0d;
+		border-bottom: 2px solid #82aaff;
+		padding: 48px 20px;
+	}
+
+	.handbook-page-header-content {
+		max-width: 1200px;
+		margin: 0 auto;
+	}
+
+	.handbook-page-title {
+		color: #c3e88d;
+		font-family: 'Fira Code', monospace;
+		font-size: 32px;
+		font-weight: 600;
+		margin: 0 0 12px 0;
+		letter-spacing: 0.5px;
+	}
+
+	.handbook-page-title::before {
+		content: '> ';
+		color: #82aaff;
+	}
+
+	.handbook-page-subtitle {
+		color: #888;
+		font-family: 'Fira Code', monospace;
+		font-size: 16px;
+		margin: 0;
+	}
+
+	.handbook-page-body {
+		display: grid;
+		grid-template-columns: 240px 1fr;
+		max-width: 1200px;
+		margin: 0 auto;
+	}
+
+	.handbook-page-nav {
+		position: sticky;
+		top: 0;
+		height: 100vh;
+		overflow-y: auto;
+		padding: 32px 16px;
+		background: #151515;
+		border-right: 1px solid #333;
+	}
+
+	.nav-links {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+	}
+
+	.nav-links li {
+		margin-bottom: 4px;
+	}
+
+	.nav-link {
+		display: block;
+		padding: 10px 12px;
+		color: #888;
+		text-decoration: none;
+		border-radius: 4px;
+		transition: all 0.2s;
+		font-size: 13px;
+		font-family: 'Fira Code', monospace;
+		position: relative;
+	}
+
+	.nav-link::before {
+		content: '$ ';
+		color: #82aaff;
+		opacity: 0;
+		transition: opacity 0.2s;
+	}
+
+	.nav-link:hover,
+	.nav-link.active {
+		color: #c3e88d;
+		background: rgba(195, 232, 141, 0.1);
+	}
+
+	.nav-link:hover::before,
+	.nav-link.active::before {
+		opacity: 1;
+	}
+
+	.nav-link-external {
+		margin-top: 8px;
+		padding-top: 12px;
+		border-top: 1px solid #333;
+	}
+
+	.nav-link-external::after {
+		content: ' ↗';
+		font-size: 12px;
+		opacity: 0.7;
+	}
+
+	.handbook-page-content {
+		overflow-y: auto;
+		padding: 32px 40px;
+		background: #1a1a1a;
+	}
+
+	.handbook-section {
+		margin-bottom: 48px;
+		scroll-margin-top: 20px;
+	}
+
+	.handbook-section h2 {
+		font-size: 20px;
+		font-weight: 600;
+		color: #82aaff;
+		margin: 0 0 20px 0;
+		padding-bottom: 10px;
+		border-bottom: 1px solid #333;
+		font-family: 'Fira Code', monospace;
+		letter-spacing: 0.5px;
+	}
+
+	.handbook-section h2::before {
+		content: '> ';
+		color: #82aaff;
+		margin-right: 10px;
+	}
+
+	.handbook-section h3 {
+		font-size: 16px;
+		font-weight: 600;
+		color: #82aaff;
+		margin: 24px 0 12px 0;
+		font-family: 'Fira Code', monospace;
+	}
+
+	.handbook-section h3::before {
+		content: '>> ';
+		color: #82aaff;
+		margin-right: 8px;
+	}
+
+	.handbook-section p {
+		line-height: 1.8;
+		margin-bottom: 18px;
+		color: #d0d0d0;
+		font-size: 14px;
+		font-family: 'Fira Code', monospace;
+	}
+
+	.handbook-section ul,
+	.handbook-section ol {
+		margin: 16px 0 24px 0;
+		line-height: 1.8;
+		padding-left: 0;
+	}
+
+	.handbook-section ul {
+		list-style: none;
+	}
+
+	.handbook-section ol {
+		list-style: none;
+		counter-reset: item;
+	}
+
+	.handbook-section li {
+		margin-bottom: 10px;
+		color: #d0d0d0;
+		font-size: 14px;
+		font-family: 'Fira Code', monospace;
+		padding-left: 24px;
+		position: relative;
+	}
+
+	.handbook-section ul li::before {
+		content: '•';
+		color: #82aaff;
+		position: absolute;
+		left: 8px;
+	}
+
+	.handbook-section ol li {
+		counter-increment: item;
+	}
+
+	.handbook-section ol li::before {
+		content: counter(item) ". ";
+		color: #82aaff;
+		position: absolute;
+		left: 0;
+		font-weight: 600;
+	}
+
+	.handbook-section strong {
+		color: #c3e88d;
+		font-weight: 600;
+	}
+
+	/* CTA Section */
+	.handbook-cta {
+		margin-top: 48px;
+		padding: 32px;
+		background: linear-gradient(135deg, rgba(130, 170, 255, 0.1) 0%, rgba(195, 232, 141, 0.1) 100%);
+		border: 1px solid rgba(130, 170, 255, 0.3);
+		border-radius: 8px;
+		text-align: center;
+	}
+
+	.cta-content h3 {
+		font-size: 20px;
+		font-weight: 600;
+		color: #82aaff;
+		margin: 0 0 12px 0;
+		font-family: 'Fira Code', monospace;
+	}
+
+	.cta-content h3::before {
+		content: '> ';
+		color: #82aaff;
+		margin-right: 8px;
+	}
+
+	.cta-content p {
+		font-size: 14px;
+		color: #d0d0d0;
+		margin: 0 0 24px 0;
+		font-family: 'Fira Code', monospace;
+		line-height: 1.6;
+	}
+
+	.cta-button {
+		display: inline-block;
+		padding: 12px 28px;
+		background: #82aaff;
+		color: #0d0d0d;
+		text-decoration: none;
+		border-radius: 6px;
+		font-family: 'Fira Code', monospace;
+		font-size: 14px;
+		font-weight: 600;
+		transition: all 0.3s ease;
+		border: 2px solid #82aaff;
+	}
+
+	.cta-button:hover {
+		background: transparent;
+		color: #82aaff;
+		transform: translateY(-2px);
+		box-shadow: 0 4px 12px rgba(130, 170, 255, 0.3);
+	}
+
+	/* Scrollbar styling */
+	.handbook-page-nav::-webkit-scrollbar,
+	.handbook-page-content::-webkit-scrollbar {
+		width: 8px;
+	}
+
+	.handbook-page-nav::-webkit-scrollbar-track,
+	.handbook-page-content::-webkit-scrollbar-track {
+		background: #0d0d0d;
+	}
+
+	.handbook-page-nav::-webkit-scrollbar-thumb,
+	.handbook-page-content::-webkit-scrollbar-thumb {
+		background: #333;
+		border-radius: 4px;
+	}
+
+	.handbook-page-nav::-webkit-scrollbar-thumb:hover,
+	.handbook-page-content::-webkit-scrollbar-thumb:hover {
+		background: #444;
+	}
+
+	/* Responsive */
+	@media (max-width: 968px) {
+		.handbook-page-body {
+			grid-template-columns: 1fr;
+			grid-template-rows: auto 1fr;
+		}
+
+		.handbook-page-nav {
+			position: relative;
+			height: auto;
+			border-right: none;
+			border-bottom: 1px solid #333;
+			padding: 16px;
+			overflow-x: auto;
+			overflow-y: hidden;
+		}
+
+		.nav-links {
+			display: flex;
+			flex-wrap: nowrap;
+			gap: 8px;
+			white-space: nowrap;
+		}
+
+		.nav-links li {
+			margin-bottom: 0;
+			flex-shrink: 0;
+		}
+
+		.nav-link {
+			padding: 8px 16px;
+			font-size: 12px;
+		}
+
+		.handbook-page-content {
+			padding: 24px 20px;
+		}
+
+		.handbook-section h2 {
+			font-size: 18px;
+		}
+
+		.handbook-section h3 {
+			font-size: 15px;
+		}
+
+		.handbook-section p,
+		.handbook-section li {
+			font-size: 13px;
+		}
+
+		.cta-content h3 {
+			font-size: 18px;
+		}
+
+		.cta-content p {
+			font-size: 13px;
+		}
+	}
+
+	@media (max-width: 768px) {
+		.handbook-page-header {
+			padding: 32px 20px;
+		}
+
+		.handbook-page-title {
+			font-size: 24px;
+		}
+
+		.handbook-page-subtitle {
+			font-size: 14px;
+		}
+
+		.handbook-page-content {
+			padding: 20px 16px;
+		}
+
+		.handbook-section {
+			margin-bottom: 36px;
+		}
+
+		.handbook-cta {
+			padding: 24px 20px;
+			margin-top: 36px;
+		}
+
+		.cta-content h3 {
+			font-size: 18px;
+		}
+
+		.cta-content p {
+			font-size: 13px;
+			margin-bottom: 20px;
+		}
+
+		.cta-button {
+			padding: 10px 24px;
+			font-size: 13px;
+		}
+	}
+
+	@media (max-width: 480px) {
+		.handbook-page-title {
+			font-size: 20px;
+		}
+
+		.handbook-page-subtitle {
+			font-size: 13px;
+		}
+
+		.handbook-page-content {
+			padding: 16px 12px;
+		}
+
+		.handbook-section h2 {
+			font-size: 16px;
+		}
+
+		.handbook-section h3 {
+			font-size: 14px;
+		}
+
+		.handbook-section p,
+		.handbook-section li {
+			font-size: 12px;
+			line-height: 1.7;
+		}
+
+		.handbook-cta {
+			padding: 20px 16px;
+			margin-top: 32px;
+		}
+
+		.cta-content h3 {
+			font-size: 16px;
+		}
+
+		.cta-content p {
+			font-size: 12px;
+			line-height: 1.7;
+			margin-bottom: 18px;
+		}
+
+		.cta-button {
+			padding: 10px 20px;
+			font-size: 12px;
+		}
+	}
+
+	/* Smooth scroll */
+	html {
+		scroll-behavior: smooth;
+	}
+
+	/* Active section highlighting */
+	.nav-link.active {
+		color: #c3e88d;
+		background: rgba(195, 232, 141, 0.15);
+	}
+</style>
+
+<script>
+	// Highlight active section in nav
+	const observer = new IntersectionObserver((entries) => {
+		entries.forEach(entry => {
+			if (entry.isIntersecting) {
+				const id = entry.target.getAttribute('id');
+				document.querySelectorAll('.nav-link').forEach(link => {
+					link.classList.remove('active');
+					if (link.getAttribute('href') === `#${id}`) {
+						link.classList.add('active');
+					}
+				});
+			}
+		});
+	}, { threshold: 0.5 });
+
+	document.querySelectorAll('.handbook-section').forEach(section => {
+		observer.observe(section);
+	});
+</script>


### PR DESCRIPTION
Created comprehensive developer marketing handbook covering goals, strategy, journey, personas, messaging, campaigns, content, community, and metrics. Implemented as both a modal overlay (accessible via floating button) and standalone SEO-optimized page at /handbook.

Key features:
- Terminal-styled modal with sidebar navigation and keyboard controls
- Standalone /handbook page for SEO with proper meta tags
- Expanded content section with 7 content types and 4 strategy buckets
- Updated metrics and community sections with latest best practices
- Footer link with subtle glow animation for discoverability
- Fully mobile responsive across all breakpoints
- Conditional rendering to hide modal button on handbook page

🤖 Generated with [Claude Code](https://claude.com/claude-code)