### PR TITLE
Add comprehensive light mode with system preference support

### DIFF
--- a/astro-site/public/assets/css/about.css
+++ b/astro-site/public/assets/css/about.css
@@ -110,7 +110,7 @@
     display: inline-block;
     width: 0;
     border-right: 2px solid #c3e88d;
-    padding-right: 2px;
+    padding-right: 12px;
     animation: typing 3.5s steps(42, end) 1s forwards, blink-caret 0.75s step-end infinite;
 }
 
@@ -1034,4 +1034,126 @@
     .connect-card {
         padding: 1rem;
     }
+}
+
+/* Light Mode Styles for About Page */
+[data-theme="light"] .about-hero {
+    background-color: var(--bg-secondary);
+    background-image:
+        linear-gradient(rgba(0, 0, 0, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 0, 0, 0.03) 1px, transparent 1px);
+    background-size: 24px 24px;
+    background-position: -1px -1px;
+}
+
+[data-theme="light"] .about-section {
+    background-color: var(--bg-secondary);
+    background-image:
+        linear-gradient(rgba(0, 0, 0, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 0, 0, 0.03) 1px, transparent 1px);
+    background-size: 24px 24px;
+    background-position: -1px -1px;
+}
+
+/* Light mode skill tags - add visible borders and background */
+[data-theme="light"] .skill-tag {
+    background: rgba(0, 0, 0, 0.04);
+    border: 1.5px solid rgba(0, 0, 0, 0.15);
+    color: var(--text-primary);
+}
+
+[data-theme="light"] .skill-tag:hover {
+    background: rgba(37, 99, 235, 0.08);
+    border-color: var(--accent-primary);
+    color: var(--accent-primary);
+}
+
+/* Light mode skill categories */
+[data-theme="light"] .skill-category {
+    background: #ffffff;
+    border: 2px solid rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .skill-category:hover {
+    border-color: rgba(37, 99, 235, 0.3);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+}
+
+/* Light mode tools section */
+[data-theme="light"] .tool-card {
+    background: #ffffff;
+    border: 2px solid rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .tool-card:hover {
+    border-color: var(--accent-primary);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+}
+
+/* Light mode talks section */
+[data-theme="light"] .talk-card {
+    background: #ffffff;
+    border: 2px solid rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .talk-card:hover {
+    border-color: var(--accent-primary);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+}
+
+/* Light mode connect cards */
+[data-theme="light"] .connect-card {
+    background: #ffffff;
+    border: 2px solid rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .connect-card:hover {
+    border-color: var(--accent-primary);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+}
+
+/* Light mode terminal quote */
+[data-theme="light"] .terminal-quote {
+    background: #f8fafc;
+    border: 2px solid rgba(37, 99, 235, 0.3);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .terminal-quote:hover {
+    border-color: var(--accent-primary);
+    box-shadow: 0 4px 16px rgba(37, 99, 235, 0.15);
+}
+
+[data-theme="light"] .terminal-prompt {
+    color: var(--accent-primary);
+}
+
+[data-theme="light"] .terminal-text {
+    color: #16a34a;
+}
+
+/* Light mode tool logo boxes */
+[data-theme="light"] .tool-logo-box {
+    background: rgba(255, 255, 255, 0.9);
+    border: 1.5px solid rgba(0, 0, 0, 0.15);
+    backdrop-filter: blur(8px);
+}
+
+[data-theme="light"] .tool-logo-box:hover {
+    border-color: rgba(37, 99, 235, 0.5);
+    box-shadow:
+        0 0 20px rgba(37, 99, 235, 0.2),
+        0 8px 24px rgba(0, 0, 0, 0.1);
+}
+
+[data-theme="light"] .tool-logo-text {
+    color: rgba(15, 23, 42, 0.85);
+    text-shadow: none;
+}
+
+[data-theme="light"] .tool-logo-box:hover .tool-logo-text {
+    color: #2563eb;
+    text-shadow:
+        0 0 8px rgba(37, 99, 235, 0.3),
+        0 0 16px rgba(37, 99, 235, 0.15);
 }

--- a/astro-site/public/assets/css/blog.css
+++ b/astro-site/public/assets/css/blog.css
@@ -535,3 +535,64 @@
         font-size: 1rem;
     }
 }
+
+/* Light Mode Styles for Blog */
+[data-theme="light"] .blog-card {
+    background-color: #ffffff;
+    background-image: none;
+    border: 2px solid rgba(0, 0, 0, 0.12);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+[data-theme="light"] .blog-card:hover {
+    border-color: var(--accent-primary);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+[data-theme="light"] .blog-hero {
+    background-color: var(--bg-secondary);
+    background-image:
+        linear-gradient(rgba(0, 0, 0, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 0, 0, 0.03) 1px, transparent 1px);
+    background-size: 24px 24px;
+    background-position: -1px -1px;
+}
+
+[data-theme="light"] .blog-feed-section {
+    background-color: var(--bg-secondary);
+    background-image:
+        linear-gradient(rgba(0, 0, 0, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 0, 0, 0.03) 1px, transparent 1px);
+    background-size: 24px 24px;
+    background-position: -1px -1px;
+}
+
+/* Light mode compact blog cards */
+[data-theme="light"] .blog-card-compact {
+    background-color: #ffffff !important;
+    background-image: none !important;
+    border: 1px solid rgba(0, 0, 0, 0.08) !important;
+}
+
+[data-theme="light"] .blog-card-compact:hover {
+    background-color: rgba(248, 250, 252, 1) !important;
+    background-image: none !important;
+    border-color: rgba(37, 99, 235, 0.3) !important;
+}
+
+[data-theme="light"] .blog-feed .blog-card:nth-child(3) {
+    border-top-color: rgba(0, 0, 0, 0.12);
+}
+
+/* Light mode blog tags */
+[data-theme="light"] .tag {
+    background: rgba(0, 0, 0, 0.04);
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    color: var(--text-secondary);
+}
+
+[data-theme="light"] .tag:hover {
+    background: rgba(37, 99, 235, 0.08);
+    border-color: var(--accent-primary);
+    color: var(--accent-primary);
+}

--- a/astro-site/public/assets/css/builds.css
+++ b/astro-site/public/assets/css/builds.css
@@ -316,3 +316,57 @@
         font-size: 0.8rem;
     }
 }
+
+/* Light Mode Styles for Builds Page */
+[data-theme="light"] .builds-hero {
+    background-color: var(--bg-secondary);
+    background-image:
+        linear-gradient(rgba(0, 0, 0, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 0, 0, 0.03) 1px, transparent 1px);
+    background-size: 24px 24px;
+    background-position: -1px -1px;
+}
+
+[data-theme="light"] .builds-section {
+    background-color: var(--bg-secondary);
+    background-image:
+        linear-gradient(rgba(0, 0, 0, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 0, 0, 0.03) 1px, transparent 1px);
+    background-size: 24px 24px;
+    background-position: -1px -1px;
+}
+
+[data-theme="light"] .build-card {
+    background: #ffffff;
+    border: 2px solid rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .build-card:hover {
+    border-color: var(--accent-primary);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+}
+
+/* Light mode build tags */
+[data-theme="light"] .tag {
+    background: rgba(0, 0, 0, 0.04);
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    color: var(--text-secondary);
+}
+
+[data-theme="light"] .tag:hover {
+    background: rgba(37, 99, 235, 0.08);
+    border-color: var(--accent-primary);
+    color: var(--accent-primary);
+}
+
+[data-theme="light"] .tech-tag {
+    background: rgba(0, 0, 0, 0.04);
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    color: var(--text-secondary);
+}
+
+[data-theme="light"] .tech-tag:hover {
+    background: rgba(37, 99, 235, 0.08);
+    border-color: var(--accent-primary);
+    color: var(--accent-primary);
+}

--- a/astro-site/public/assets/css/dark-mode.css
+++ b/astro-site/public/assets/css/dark-mode.css
@@ -1,6 +1,7 @@
 /* Dark Mode Developer-Focused Design */
 
 :root {
+    /* Dark mode colors (default) */
     --bg-primary: #0a0e27;
     --bg-secondary: #151932;
     --bg-tertiary: #1e2442;
@@ -10,10 +11,31 @@
     --accent-secondary: #818cf8;
     --accent-yellow: #fbbf24;
     --accent-green: #34d399;
+    --accent-blue: #60a5fa;
+    --accent-purple: #a855f7;
     --code-keyword: #c792ea;
     --code-string: #c3e88d;
     --code-property: #82aaff;
     --code-comment: #697098;
+}
+
+/* Light mode colors */
+[data-theme="light"] {
+    --bg-primary: #ffffff;
+    --bg-secondary: #f8fafc;
+    --bg-tertiary: #f1f5f9;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --accent-primary: #2563eb;
+    --accent-secondary: #4f46e5;
+    --accent-yellow: #d97706;
+    --accent-green: #059669;
+    --accent-blue: #2563eb;
+    --accent-purple: #7c3aed;
+    --code-keyword: #9333ea;
+    --code-string: #16a34a;
+    --code-property: #0284c7;
+    --code-comment: #64748b;
 }
 
 * {
@@ -1159,5 +1181,155 @@ html {
 
     .github-cta-title {
         font-size: 1.125rem;
+    }
+}
+
+/* Theme Toggle Button Styles */
+.theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 45px;
+    height: 45px;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: all 0.3s ease;
+    font-size: 1.25rem;
+    margin-left: 0.75rem;
+}
+
+.theme-toggle:hover {
+    background: rgba(96, 165, 250, 0.15);
+    border-color: var(--accent-primary);
+    transform: translateY(-3px);
+}
+
+.theme-toggle i {
+    transition: transform 0.3s ease;
+}
+
+.theme-toggle:hover i {
+    transform: rotate(20deg);
+}
+
+/* Light mode body with subtle texture */
+[data-theme="light"] body {
+    background-color: var(--bg-secondary);
+    background-image:
+        linear-gradient(rgba(0, 0, 0, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 0, 0, 0.03) 1px, transparent 1px);
+    background-size: 24px 24px;
+    background-position: -1px -1px;
+}
+
+/* Light mode adjustments */
+[data-theme="light"] .theme-toggle {
+    background: rgba(0, 0, 0, 0.05);
+    border-color: rgba(0, 0, 0, 0.1);
+}
+
+[data-theme="light"] .theme-toggle:hover {
+    background: rgba(37, 99, 235, 0.1);
+    border-color: var(--accent-primary);
+}
+
+/* Smooth transitions for theme changes */
+body,
+.navbar,
+.code-greeting,
+.feed-item,
+.timeline-content,
+.btn-modern,
+.footer {
+    transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
+/* Light mode navbar adjustments */
+[data-theme="light"] .navbar {
+    background: rgba(248, 250, 252, 0.9) !important;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+[data-theme="light"] .navbar-toggler {
+    border-color: rgba(0, 0, 0, 0.2) !important;
+}
+
+[data-theme="light"] .navbar-toggler-icon {
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%280, 0, 0, 0.7%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e") !important;
+}
+
+/* Light mode hero section */
+[data-theme="light"] .hero-section {
+    background-color: var(--bg-secondary);
+    background-image:
+        radial-gradient(circle at 20% 50%, rgba(37, 99, 235, 0.08) 0%, transparent 50%),
+        radial-gradient(circle at 80% 80%, rgba(79, 70, 229, 0.08) 0%, transparent 50%),
+        linear-gradient(rgba(0, 0, 0, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 0, 0, 0.03) 1px, transparent 1px);
+    background-size: 100% 100%, 100% 100%, 24px 24px, 24px 24px;
+    background-position: 0 0, 0 0, -1px -1px, -1px -1px;
+}
+
+[data-theme="light"] .hero-section::before {
+    display: none;
+}
+
+/* Light mode code greeting */
+[data-theme="light"] .code-greeting {
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.08);
+    border-color: rgba(0, 0, 0, 0.1);
+}
+
+[data-theme="light"] .code-greeting::before {
+    background: linear-gradient(90deg, var(--accent-primary), var(--accent-secondary));
+}
+
+/* Light mode footer */
+[data-theme="light"] .footer {
+    border-top-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+[data-theme="light"] .footer-social a {
+    background: rgba(0, 0, 0, 0.05);
+}
+
+[data-theme="light"] .footer-social a:hover {
+    background: rgba(37, 99, 235, 0.1);
+}
+
+/* Light mode feed items - increase contrast */
+[data-theme="light"] .feed-item {
+    background: #ffffff;
+    border: 2px solid rgba(0, 0, 0, 0.12);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+[data-theme="light"] .feed-item:hover {
+    border-color: var(--accent-primary);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+/* Light mode featured content section */
+[data-theme="light"] .featured-content {
+    background: var(--bg-secondary);
+}
+
+/* Mobile theme toggle */
+@media (max-width: 768px) {
+    .theme-toggle-desktop {
+        display: none !important;
+    }
+
+    .theme-toggle-mobile {
+        display: block !important;
+    }
+}
+
+@media (min-width: 769px) {
+    .theme-toggle-mobile {
+        display: none !important;
     }
 }

--- a/astro-site/public/assets/css/gems.css
+++ b/astro-site/public/assets/css/gems.css
@@ -973,3 +973,226 @@ html {
         padding-top: 2rem;
     }
 }
+
+/* Light Mode Styles for Gems Page */
+[data-theme="light"] .about-hero {
+    background-color: var(--bg-secondary);
+    background-image:
+        linear-gradient(rgba(0, 0, 0, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 0, 0, 0.03) 1px, transparent 1px);
+    background-size: 24px 24px;
+    background-position: -1px -1px;
+}
+
+[data-theme="light"] .gems-section {
+    background-color: var(--bg-secondary);
+    background-image:
+        linear-gradient(rgba(0, 0, 0, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 0, 0, 0.03) 1px, transparent 1px);
+    background-size: 24px 24px;
+    background-position: -1px -1px;
+}
+
+/* Light mode scroll hint */
+[data-theme="light"] .scroll-hint {
+    background: rgba(37, 99, 235, 0.08);
+    border: 1.5px solid rgba(37, 99, 235, 0.3);
+    color: var(--text-primary);
+    opacity: 1;
+}
+
+[data-theme="light"] .scroll-hint:hover {
+    background: rgba(37, 99, 235, 0.12);
+    border-color: var(--accent-primary);
+}
+
+[data-theme="light"] .scroll-hint .comment-slash {
+    color: var(--code-comment);
+}
+
+/* Light mode featured gem */
+[data-theme="light"] .featured-gem {
+    background: #ffffff;
+    border: 2px solid rgba(0, 0, 0, 0.12);
+}
+
+[data-theme="light"] .featured-gem:hover {
+    background: #ffffff;
+    border-color: var(--accent-primary);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+[data-theme="light"] .featured-gem-content {
+    background: transparent;
+}
+
+[data-theme="light"] .featured-gem-title a {
+    background: rgba(37, 99, 235, 0.08);
+    color: var(--text-primary);
+}
+
+[data-theme="light"] .featured-gem-title a:hover {
+    background: rgba(37, 99, 235, 0.12);
+    color: var(--accent-primary);
+}
+
+[data-theme="light"] .featured-gem-description {
+    color: var(--text-secondary);
+}
+
+[data-theme="light"] .featured-gem .gem-tag:first-child {
+    background: rgba(37, 99, 235, 0.12);
+    color: var(--accent-primary);
+    border-color: rgba(37, 99, 235, 0.3);
+}
+
+/* Light mode tab buttons */
+[data-theme="light"] .tab-button {
+    background: rgba(0, 0, 0, 0.05);
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    color: var(--text-secondary);
+}
+
+[data-theme="light"] .tab-button.active {
+    background: var(--accent-primary);
+    color: #ffffff;
+    border-color: var(--accent-primary);
+}
+
+[data-theme="light"] .tab-button:hover:not(.active) {
+    background: rgba(37, 99, 235, 0.08);
+    border-color: rgba(37, 99, 235, 0.3);
+}
+
+/* Light mode timeline entries */
+[data-theme="light"] .timeline-content {
+    background: #ffffff;
+    border: 2px solid rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .timeline-entry:hover .timeline-content {
+    border-color: var(--accent-primary);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .timeline-marker {
+    background: #0ea5e9;
+    border-color: var(--bg-secondary);
+    box-shadow: 0 0 0 2px var(--bg-secondary), 0 0 8px rgba(14, 165, 233, 0.3);
+}
+
+[data-theme="light"] .timeline-container::before {
+    background: #0ea5e9;
+    width: 3px;
+}
+
+/* Light mode gem tags */
+[data-theme="light"] .gem-tag {
+    background: rgba(0, 0, 0, 0.05);
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    color: var(--text-secondary);
+}
+
+[data-theme="light"] .gem-tag:hover {
+    background: rgba(37, 99, 235, 0.08);
+    border-color: var(--accent-primary);
+    color: var(--accent-primary);
+}
+
+/* Light mode gem titles and descriptions */
+[data-theme="light"] .gem-title a {
+    color: var(--text-primary);
+}
+
+[data-theme="light"] .gem-title a:hover {
+    color: var(--accent-primary);
+}
+
+[data-theme="light"] .gem-description {
+    color: var(--text-secondary);
+}
+
+/* Light mode websites table */
+[data-theme="light"] .websites-table {
+    background: transparent;
+    border: 2px solid rgba(0, 0, 0, 0.12);
+}
+
+[data-theme="light"] .websites-table thead {
+    background: rgba(37, 99, 235, 0.08);
+    border-bottom: 2px solid rgba(0, 0, 0, 0.12);
+}
+
+[data-theme="light"] .websites-table th {
+    color: var(--text-primary);
+    border-bottom: 2px solid rgba(0, 0, 0, 0.12);
+}
+
+[data-theme="light"] .websites-table td {
+    color: var(--text-primary);
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+[data-theme="light"] .websites-table tbody tr {
+    background: rgba(255, 255, 255, 0.6);
+}
+
+[data-theme="light"] .websites-table tbody tr:hover {
+    background: rgba(37, 99, 235, 0.08);
+}
+
+[data-theme="light"] .website-link {
+    color: var(--text-primary);
+}
+
+[data-theme="light"] .website-link:hover {
+    color: var(--accent-primary);
+}
+
+[data-theme="light"] .website-category {
+    color: var(--text-primary);
+    font-weight: 500;
+}
+
+[data-theme="light"] .website-date {
+    color: var(--text-primary);
+}
+
+[data-theme="light"] .col-date {
+    color: var(--text-primary);
+    opacity: 0.8;
+}
+
+[data-theme="light"] .table-row:hover .col-date {
+    color: var(--text-primary);
+    opacity: 1;
+}
+
+[data-theme="light"] .col-type {
+    color: var(--text-primary);
+    opacity: 0.8;
+}
+
+[data-theme="light"] .table-row:hover .col-type {
+    color: var(--accent-purple);
+    opacity: 1;
+}
+
+/* Light mode table rows - add visible borders */
+[data-theme="light"] .table-row {
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .table-row:hover {
+    background: rgba(37, 99, 235, 0.04);
+}
+
+/* Light mode favorite badge */
+[data-theme="light"] .favorite-badge {
+    background: linear-gradient(135deg, #ec4899, #a855f7);
+}
+
+/* Light mode fancy websites section */
+[data-theme="light"] .fancy-websites-section {
+    background: var(--bg-secondary);
+}

--- a/astro-site/src/components/DevMarketingConsole.astro
+++ b/astro-site/src/components/DevMarketingConsole.astro
@@ -873,6 +873,152 @@ If it doesn't show developer impact, it's just noise.`
       font-size: 12px;
     }
   }
+
+  /* Light Mode Styles */
+  :global([data-theme="light"]) .dev-console-button {
+    background: #ffffff;
+    color: #16a34a;
+    border: 2px solid #16a34a;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  }
+
+  :global([data-theme="light"]) .dev-console-button:hover {
+    background: #f0fdf4;
+    box-shadow: 0 6px 16px rgba(22, 163, 74, 0.2);
+  }
+
+  :global([data-theme="light"]) .dev-console-overlay.active {
+    background: rgba(0, 0, 0, 0.5);
+  }
+
+  :global([data-theme="light"]) .handbook-modal {
+    background: #ffffff;
+    border-color: #2563eb;
+    box-shadow: 0 20px 60px rgba(37, 99, 235, 0.15), 0 0 0 1px rgba(37, 99, 235, 0.1);
+  }
+
+  :global([data-theme="light"]) .handbook-header {
+    background: #f8fafc;
+    border-bottom-color: #e2e8f0;
+  }
+
+  :global([data-theme="light"]) .handbook-title {
+    color: #16a34a;
+  }
+
+  :global([data-theme="light"]) .handbook-title::before {
+    color: #2563eb;
+  }
+
+  :global([data-theme="light"]) .handbook-close {
+    color: #2563eb;
+  }
+
+  :global([data-theme="light"]) .handbook-close:hover {
+    color: #dc2626;
+  }
+
+  :global([data-theme="light"]) .handbook-nav {
+    background: #f8fafc;
+    border-right-color: #e2e8f0;
+  }
+
+  :global([data-theme="light"]) .nav-link {
+    color: #64748b;
+  }
+
+  :global([data-theme="light"]) .nav-link::before {
+    color: #2563eb;
+  }
+
+  :global([data-theme="light"]) .nav-link:hover,
+  :global([data-theme="light"]) .nav-link.active {
+    color: #16a34a;
+    background: rgba(22, 163, 74, 0.08);
+  }
+
+  :global([data-theme="light"]) .nav-link-external {
+    border-top-color: #e2e8f0;
+  }
+
+  :global([data-theme="light"]) .handbook-content {
+    background: #ffffff;
+  }
+
+  :global([data-theme="light"]) .handbook-section h2 {
+    color: #2563eb;
+    border-bottom-color: #e2e8f0;
+  }
+
+  :global([data-theme="light"]) .handbook-section h2::before {
+    color: #2563eb;
+  }
+
+  :global([data-theme="light"]) .handbook-section h3 {
+    color: #2563eb;
+  }
+
+  :global([data-theme="light"]) .handbook-section h3::before {
+    color: #2563eb;
+  }
+
+  :global([data-theme="light"]) .handbook-section p,
+  :global([data-theme="light"]) .handbook-section li {
+    color: #475569;
+  }
+
+  :global([data-theme="light"]) .handbook-section ul li::before,
+  :global([data-theme="light"]) .handbook-section ol li::before {
+    color: #2563eb;
+  }
+
+  :global([data-theme="light"]) .handbook-section strong {
+    color: #16a34a;
+  }
+
+  :global([data-theme="light"]) .handbook-cta {
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.08) 0%, rgba(22, 163, 74, 0.08) 100%);
+    border-color: rgba(37, 99, 235, 0.3);
+  }
+
+  :global([data-theme="light"]) .cta-content h3 {
+    color: #2563eb;
+  }
+
+  :global([data-theme="light"]) .cta-content h3::before {
+    color: #2563eb;
+  }
+
+  :global([data-theme="light"]) .cta-content p {
+    color: #475569;
+  }
+
+  :global([data-theme="light"]) .cta-button {
+    background: #2563eb;
+    color: #ffffff;
+    border-color: #2563eb;
+  }
+
+  :global([data-theme="light"]) .cta-button:hover {
+    background: transparent;
+    color: #2563eb;
+    box-shadow: 0 4px 12px rgba(37, 99, 235, 0.2);
+  }
+
+  :global([data-theme="light"]) .handbook-nav::-webkit-scrollbar-track,
+  :global([data-theme="light"]) .handbook-content::-webkit-scrollbar-track {
+    background: #f1f5f9;
+  }
+
+  :global([data-theme="light"]) .handbook-nav::-webkit-scrollbar-thumb,
+  :global([data-theme="light"]) .handbook-content::-webkit-scrollbar-thumb {
+    background: #cbd5e1;
+  }
+
+  :global([data-theme="light"]) .handbook-nav::-webkit-scrollbar-thumb:hover,
+  :global([data-theme="light"]) .handbook-content::-webkit-scrollbar-thumb:hover {
+    background: #94a3b8;
+  }
 </style>
 
 <script>

--- a/astro-site/src/components/Footer.astro
+++ b/astro-site/src/components/Footer.astro
@@ -84,6 +84,35 @@
             font-size: 12px;
         }
     }
+
+    /* Light mode footer link */
+    :global([data-theme="light"]) .footer-link {
+        color: var(--text-secondary);
+        border-color: rgba(0, 0, 0, 0.15);
+    }
+
+    :global([data-theme="light"]) .footer-link:hover {
+        color: #16a34a;
+        border-color: #16a34a;
+        box-shadow: 0 0 10px rgba(22, 163, 74, 0.2);
+    }
+
+    @keyframes subtle-glow-light {
+        0%, 100% {
+            box-shadow: 0 0 5px rgba(22, 163, 74, 0.1);
+        }
+        50% {
+            box-shadow: 0 0 8px rgba(22, 163, 74, 0.15);
+        }
+    }
+
+    :global([data-theme="light"]) .footer-link {
+        animation: subtle-glow-light 3s ease-in-out infinite;
+    }
+
+    :global([data-theme="light"]) .footer-link:hover {
+        animation: none;
+    }
 </style>
 
 <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"

--- a/astro-site/src/components/Navbar.astro
+++ b/astro-site/src/components/Navbar.astro
@@ -32,6 +32,16 @@
                     <i class="fa-brands fa-github"></i>
                 </a>
             </li>
+            <li class="nav-item theme-toggle-mobile">
+                <a class="nav-link" id="themeToggleMobile" aria-label="Toggle theme" title="Toggle theme" style="cursor: pointer;">
+                    <i class="fa-solid fa-sun" id="themeIconMobile"></i>
+                </a>
+            </li>
+            <li class="nav-item theme-toggle-desktop-nav">
+                <button class="theme-toggle theme-toggle-desktop" id="themeToggle" aria-label="Toggle theme" title="Toggle theme" style="border: none; background: none; padding: 0; margin-left: 1rem;">
+                    <i class="fa-solid fa-sun" id="themeIcon"></i>
+                </button>
+            </li>
         </ul>
     </div>
 </nav>

--- a/astro-site/src/layouts/Layout.astro
+++ b/astro-site/src/layouts/Layout.astro
@@ -88,11 +88,81 @@ const {
 	<meta name="application-name" content="LucasStahl" />
 	<meta name="msapplication-TileColor" content="#FFFFFF" />
 	<meta name="msapplication-TileImage" content="https://lucasstahl.com/LS.ico" />
+
+	<!-- Theme Script (runs immediately to prevent flash) -->
+	<script is:inline>
+		// Initialize theme before page renders to prevent flash
+		(function() {
+			const savedTheme = localStorage.getItem('theme');
+			let theme;
+
+			if (savedTheme) {
+				// User has manually set a preference
+				theme = savedTheme;
+			} else {
+				// Check system preference
+				const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+				theme = prefersDark ? 'dark' : 'light';
+			}
+
+			document.documentElement.setAttribute('data-theme', theme);
+		})();
+	</script>
 </head>
 <body>
 	<Navbar />
 	<slot />
 	<Footer />
 	{!hideHandbookButton && <DevMarketingConsole />}
+
+	<!-- Theme Toggle Functionality -->
+	<script is:inline>
+		document.addEventListener('DOMContentLoaded', function() {
+			const themeToggle = document.getElementById('themeToggle');
+			const themeToggleMobile = document.getElementById('themeToggleMobile');
+			const themeIcon = document.getElementById('themeIcon');
+			const themeIconMobile = document.getElementById('themeIconMobile');
+			const html = document.documentElement;
+
+			// Get current theme
+			function getCurrentTheme() {
+				return html.getAttribute('data-theme') || 'dark';
+			}
+
+			// Update icon based on current theme
+			function updateIcon() {
+				const currentTheme = getCurrentTheme();
+				const icon = currentTheme === 'dark' ? 'fa-sun' : 'fa-moon';
+
+				if (themeIcon) {
+					themeIcon.className = `fa-solid ${icon}`;
+				}
+				if (themeIconMobile) {
+					themeIconMobile.className = `fa-solid ${icon}`;
+				}
+			}
+
+			// Toggle theme
+			function toggleTheme() {
+				const currentTheme = getCurrentTheme();
+				const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+
+				html.setAttribute('data-theme', newTheme);
+				localStorage.setItem('theme', newTheme);
+				updateIcon();
+			}
+
+			// Set up event listeners
+			if (themeToggle) {
+				themeToggle.addEventListener('click', toggleTheme);
+			}
+			if (themeToggleMobile) {
+				themeToggleMobile.addEventListener('click', toggleTheme);
+			}
+
+			// Initialize icon
+			updateIcon();
+		});
+	</script>
 </body>
 </html>

--- a/astro-site/src/pages/blog.astro
+++ b/astro-site/src/pages/blog.astro
@@ -66,6 +66,20 @@ const notionPosts = await getBlogPosts();
 				padding: 0.45rem 0.9rem;
 			}
 		}
+
+		/* Light mode RSS button */
+		:global([data-theme="light"]) .rss-subscribe-button {
+			background-color: rgba(14, 165, 233, 0.1);
+			border: 1.5px solid rgba(14, 165, 233, 0.4);
+			color: #0284c7;
+		}
+
+		:global([data-theme="light"]) .rss-subscribe-button:hover {
+			background-color: rgba(14, 165, 233, 0.15);
+			border-color: #0284c7;
+			color: #0284c7;
+			box-shadow: 0 0 10px rgba(14, 165, 233, 0.2);
+		}
 	</style>
 
 	<!-- Blog Feed Section -->

--- a/astro-site/src/pages/handbook.astro
+++ b/astro-site/src/pages/handbook.astro
@@ -631,6 +631,107 @@ import Layout from '../layouts/Layout.astro';
 		color: #c3e88d;
 		background: rgba(195, 232, 141, 0.15);
 	}
+
+	/* Light Mode Styles for Handbook Page */
+	:global([data-theme="light"]) .handbook-page-container {
+		background: var(--bg-secondary);
+	}
+
+	:global([data-theme="light"]) .handbook-page-header {
+		background: #f8fafc;
+		border-bottom-color: #e2e8f0;
+	}
+
+	:global([data-theme="light"]) .handbook-page-title {
+		color: #16a34a;
+	}
+
+	:global([data-theme="light"]) .handbook-page-title::before {
+		color: #2563eb;
+	}
+
+	:global([data-theme="light"]) .handbook-page-nav {
+		background: #f8fafc;
+		border-right-color: #e2e8f0;
+	}
+
+	:global([data-theme="light"]) .nav-link {
+		color: #64748b;
+	}
+
+	:global([data-theme="light"]) .nav-link::before {
+		color: #2563eb;
+	}
+
+	:global([data-theme="light"]) .nav-link:hover,
+	:global([data-theme="light"]) .nav-link.active {
+		color: #16a34a;
+		background: rgba(22, 163, 74, 0.08);
+	}
+
+	:global([data-theme="light"]) .handbook-page-content {
+		background: #ffffff;
+	}
+
+	:global([data-theme="light"]) .handbook-section h2 {
+		color: #2563eb;
+		border-bottom-color: #e2e8f0;
+	}
+
+	:global([data-theme="light"]) .handbook-section h2::before {
+		color: #2563eb;
+	}
+
+	:global([data-theme="light"]) .handbook-section h3 {
+		color: #2563eb;
+	}
+
+	:global([data-theme="light"]) .handbook-section h3::before {
+		color: #2563eb;
+	}
+
+	:global([data-theme="light"]) .handbook-section p,
+	:global([data-theme="light"]) .handbook-section li {
+		color: #475569;
+	}
+
+	:global([data-theme="light"]) .handbook-section ul li::before,
+	:global([data-theme="light"]) .handbook-section ol li::before {
+		color: #2563eb;
+	}
+
+	:global([data-theme="light"]) .handbook-section strong {
+		color: #16a34a;
+	}
+
+	:global([data-theme="light"]) .handbook-cta {
+		background: linear-gradient(135deg, rgba(37, 99, 235, 0.08) 0%, rgba(22, 163, 74, 0.08) 100%);
+		border-color: rgba(37, 99, 235, 0.3);
+	}
+
+	:global([data-theme="light"]) .cta-content h3 {
+		color: #2563eb;
+	}
+
+	:global([data-theme="light"]) .cta-content h3::before {
+		color: #2563eb;
+	}
+
+	:global([data-theme="light"]) .cta-content p {
+		color: #475569;
+	}
+
+	:global([data-theme="light"]) .cta-button {
+		background: #2563eb;
+		color: #ffffff;
+		border-color: #2563eb;
+	}
+
+	:global([data-theme="light"]) .cta-button:hover {
+		background: transparent;
+		color: #2563eb;
+		box-shadow: 0 4px 12px rgba(37, 99, 235, 0.2);
+	}
 </style>
 
 <script>


### PR DESCRIPTION
Implemented a complete light mode theme system that respects user system preferences while maintaining manual toggle functionality. All pages now have optimized light mode styling with proper contrast and accessibility.

Key features:
- System preference detection (prefers-color-scheme)
- Manual theme toggle in navbar with localStorage persistence
- User preference always takes priority over system settings
- Comprehensive light mode styles across all pages (Home, Blog, Builds, About, Gems, Handbook)
- Grid texture backgrounds for light mode
- Accessible contrast ratios for all text and interactive elements
- Smooth transitions between themes
- Fixed terminal typing cursor overlap on About page
- Light mode styling for tool pills in My Stack section

🤖 Generated with [Claude Code](https://claude.com/claude-code)