### PR TITLE
Add terminal-style search functionality with three-state theme toggle

### DIFF
--- a/astro-site/package-lock.json
+++ b/astro-site/package-lock.json
@@ -12,6 +12,7 @@
         "@astrojs/sitemap": "^3.6.0",
         "@notionhq/client": "^2.3.0",
         "astro": "^5.15.8",
+        "fuse.js": "^7.1.0",
         "marked": "^17.0.1",
         "notion-to-md": "^3.1.9"
       }
@@ -2639,6 +2640,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/get-east-asian-width": {

--- a/astro-site/package.json
+++ b/astro-site/package.json
@@ -14,6 +14,7 @@
     "@astrojs/sitemap": "^3.6.0",
     "@notionhq/client": "^2.3.0",
     "astro": "^5.15.8",
+    "fuse.js": "^7.1.0",
     "marked": "^17.0.1",
     "notion-to-md": "^3.1.9"
   }

--- a/astro-site/public/assets/css/dark-mode.css
+++ b/astro-site/public/assets/css/dark-mode.css
@@ -1275,13 +1275,13 @@ html {
     cursor: pointer;
     transition: all 0.3s ease;
     font-size: 1.25rem;
-    margin-left: 0.75rem;
+    transform: translateY(-3px);
 }
 
 .theme-toggle:hover {
     background: rgba(96, 165, 250, 0.15);
     border-color: var(--accent-primary);
-    transform: translateY(-3px);
+    transform: translateY(-6px);
 }
 
 .theme-toggle i {

--- a/astro-site/public/assets/css/search.css
+++ b/astro-site/public/assets/css/search.css
@@ -1,0 +1,417 @@
+/* Search Modal Styles */
+.search-modal {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 9999;
+  animation: fadeIn 0.2s ease;
+}
+
+.search-modal.active {
+  display: block;
+}
+
+.search-modal-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(4px);
+}
+
+.search-modal-content {
+  position: relative;
+  max-width: 680px;
+  margin: 80px auto 0;
+  background: #0a0e27;
+  border: 2px solid #2a2f4a;
+  border-radius: 8px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.7);
+  overflow: hidden;
+  animation: slideDown 0.3s ease;
+}
+
+/* Terminal Header */
+.search-modal-content::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 36px;
+  background: linear-gradient(180deg, #1e2442 0%, #151932 100%);
+  border-bottom: 1px solid #2a2f4a;
+  z-index: 10;
+}
+
+/* Terminal Window Controls */
+.search-modal-content::after {
+  content: '';
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  width: 12px;
+  height: 12px;
+  background: #ff5f56;
+  border-radius: 50%;
+  box-shadow:
+    18px 0 0 #ffbd2e,
+    36px 0 0 #27c93f;
+  z-index: 11;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.search-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.25rem;
+  padding-top: 52px;
+  border-bottom: 1px solid #2a2f4a;
+  background: rgba(10, 14, 39, 0.5);
+  position: relative;
+  z-index: 1;
+}
+
+.search-input-wrapper {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.search-icon {
+  color: #e5f088;
+  font-size: 1.1rem;
+}
+
+/* Terminal prompt indicator */
+.search-input-wrapper::before {
+  content: '$';
+  color: #e5f088;
+  font-family: 'Fira Code', monospace;
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-right: 0.5rem;
+}
+
+.search-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: #e5f088;
+  font-family: 'Fira Code', monospace;
+  font-size: 0.95rem;
+  padding: 0;
+  letter-spacing: 0.01em;
+}
+
+.search-input::placeholder {
+  color: rgba(229, 240, 136, 0.3);
+  font-family: 'Fira Code', monospace;
+}
+
+.search-kbd {
+  padding: 0.25rem 0.5rem;
+  background: rgba(96, 165, 250, 0.1);
+  border: 1px solid rgba(96, 165, 250, 0.2);
+  border-radius: 4px;
+  color: #60a5fa;
+  font-family: 'Fira Code', monospace;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.search-close {
+  background: none;
+  border: none;
+  color: rgba(228, 228, 231, 0.6);
+  font-size: 1.25rem;
+  cursor: pointer;
+  padding: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s ease;
+}
+
+.search-close:hover {
+  color: #e4e4e7;
+}
+
+.search-results {
+  max-height: 400px;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  background: #0a0e27;
+}
+
+.search-results::-webkit-scrollbar {
+  width: 8px;
+}
+
+.search-results::-webkit-scrollbar-track {
+  background: rgba(96, 165, 250, 0.05);
+}
+
+.search-results::-webkit-scrollbar-thumb {
+  background: rgba(96, 165, 250, 0.2);
+  border-radius: 4px;
+}
+
+.search-results::-webkit-scrollbar-thumb:hover {
+  background: rgba(96, 165, 250, 0.3);
+}
+
+.search-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 2rem;
+  color: rgba(228, 228, 231, 0.4);
+}
+
+.search-empty i {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  opacity: 0.3;
+}
+
+.search-empty p {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.95rem;
+}
+
+/* Recent Content Header */
+.search-recent-header {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(228, 228, 231, 0.4);
+  padding: 0.75rem 1.25rem 0.5rem;
+}
+
+/* Search Result Items */
+.search-result-item {
+  display: block;
+  padding: 1.25rem 1.25rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  border-bottom: 1px solid rgba(96, 165, 250, 0.15);
+  text-decoration: none;
+  background: transparent;
+}
+
+.search-result-item:first-child {
+  padding-top: 0.75rem;
+}
+
+.search-result-item:last-child {
+  border-bottom: none;
+  padding-bottom: 0.75rem;
+}
+
+.search-result-item:hover,
+.search-result-item.active {
+  background: rgba(96, 165, 250, 0.06);
+}
+
+.search-result-path {
+  font-family: 'Fira Code', monospace;
+  font-size: 0.75rem;
+  color: #e5f088 !important;
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+}
+
+.search-result-title {
+  font-family: 'Inter', sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #e4e4e7 !important;
+  margin-bottom: 0.4rem;
+  line-height: 1.4;
+}
+
+.search-result-description {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.85rem;
+  color: rgba(228, 228, 231, 0.5) !important;
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.search-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.875rem 1.25rem;
+  border-top: 1px solid #2a2f4a;
+  background: #151932;
+}
+
+.search-footer-left,
+.search-footer-right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.search-footer kbd {
+  padding: 0.25rem 0.5rem;
+  background: rgba(96, 165, 250, 0.1);
+  border: 1px solid rgba(96, 165, 250, 0.2);
+  border-radius: 4px;
+  color: #60a5fa;
+  font-family: 'Fira Code', monospace;
+  font-size: 0.75rem;
+}
+
+.search-footer span {
+  color: rgba(228, 228, 231, 0.5);
+  font-family: 'Inter', sans-serif;
+  font-size: 0.8rem;
+}
+
+.search-no-results {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 2rem;
+  color: rgba(228, 228, 231, 0.4);
+}
+
+.search-no-results i {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  opacity: 0.3;
+}
+
+.search-no-results p {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.95rem;
+}
+
+/* Light mode styles */
+[data-theme="light"] .search-modal-content {
+  background: #f8fafc;
+  border: 2px solid #cbd5e1;
+}
+
+[data-theme="light"] .search-modal-content::before {
+  background: linear-gradient(180deg, #e2e8f0 0%, #cbd5e1 100%);
+  border-bottom-color: #94a3b8;
+}
+
+[data-theme="light"] .search-modal-content::after {
+  background: #ff5f56;
+  box-shadow:
+    18px 0 0 #ffbd2e,
+    36px 0 0 #27c93f;
+}
+
+[data-theme="light"] .search-header {
+  border-bottom-color: #cbd5e1;
+  background: rgba(248, 250, 252, 0.8);
+}
+
+[data-theme="light"] .search-icon {
+  color: #16a34a;
+}
+
+[data-theme="light"] .search-input-wrapper::before {
+  color: #16a34a;
+}
+
+[data-theme="light"] .search-input {
+  color: #16a34a;
+}
+
+[data-theme="light"] .search-input::placeholder {
+  color: rgba(15, 23, 42, 0.4);
+}
+
+[data-theme="light"] .search-results {
+  background: #f8fafc;
+}
+
+[data-theme="light"] .search-close {
+  color: rgba(26, 26, 26, 0.6);
+}
+
+[data-theme="light"] .search-close:hover {
+  color: #1a1a1a;
+}
+
+[data-theme="light"] .search-result-item {
+  border-bottom-color: rgba(14, 116, 218, 0.12);
+}
+
+[data-theme="light"] .search-result-item:hover,
+[data-theme="light"] .search-result-item.active {
+  background: rgba(14, 116, 218, 0.06);
+}
+
+[data-theme="light"] .search-result-path {
+  color: #16a34a !important;
+}
+
+[data-theme="light"] .search-result-title {
+  color: #1a1a1a !important;
+}
+
+[data-theme="light"] .search-result-description {
+  color: rgba(26, 26, 26, 0.6) !important;
+}
+
+[data-theme="light"] .search-recent-header {
+  color: rgba(26, 26, 26, 0.4);
+}
+
+[data-theme="light"] .search-footer {
+  border-top-color: #cbd5e1;
+  background: #e2e8f0;
+}
+
+@media (max-width: 768px) {
+  .search-modal-content {
+    margin: 20px 16px 0;
+    max-width: none;
+  }
+
+  .search-results {
+    max-height: 300px;
+  }
+
+  .search-input {
+    font-size: 1rem;
+  }
+}

--- a/astro-site/src/components/Navbar.astro
+++ b/astro-site/src/components/Navbar.astro
@@ -30,6 +30,11 @@
             <li class="nav-item">
                 <a class="nav-link" href="/gems" data-nav-link>Gems</a>
             </li>
+            <li class="nav-item search-nav-item">
+                <button class="nav-link search-button" id="searchButton" aria-label="Search" title="Search (⌘K)" style="border: none; background: none; cursor: pointer;">
+                    <i class="fa-solid fa-search"></i>
+                </button>
+            </li>
             <li class="nav-item navbar-github-mobile">
                 <a class="nav-link" href="https://github.com/Stahlwalker" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
                     <i class="fa-brands fa-github"></i>
@@ -46,7 +51,7 @@
                 </a>
             </li>
             <li class="nav-item theme-toggle-desktop-nav">
-                <button class="theme-toggle theme-toggle-desktop" id="themeToggle" aria-label="Toggle theme" title="Toggle theme" style="border: none; background: none; padding: 0; margin-left: 1rem;">
+                <button class="theme-toggle theme-toggle-desktop" id="themeToggle" aria-label="Toggle theme" title="Toggle theme" style="border: none; background: none; padding: 0;">
                     <i class="fa-solid fa-sun" id="themeIcon"></i>
                 </button>
             </li>
@@ -65,5 +70,15 @@
                 window.location.href = fullUrl;
             });
         });
+
+        // Search button handler
+        const searchButton = document.getElementById('searchButton');
+        if (searchButton) {
+            searchButton.addEventListener('click', function() {
+                if (window.openSearchModal) {
+                    window.openSearchModal();
+                }
+            });
+        }
     });
 </script>

--- a/astro-site/src/components/Search.astro
+++ b/astro-site/src/components/Search.astro
@@ -1,0 +1,318 @@
+---
+import { buildSearchIndex } from '../lib/searchIndex';
+
+const searchIndex = await buildSearchIndex();
+---
+
+<!-- Search Modal -->
+<div id="search-modal" class="search-modal">
+  <div class="search-modal-overlay"></div>
+  <div class="search-modal-content">
+    <div class="search-header">
+      <div class="search-input-wrapper">
+        <i class="fa-solid fa-search search-icon"></i>
+        <input
+          type="text"
+          id="search-input"
+          class="search-input"
+          placeholder="Try: developer marketing, React, AI..."
+          autocomplete="off"
+          spellcheck="false"
+        />
+        <kbd class="search-kbd">ESC</kbd>
+      </div>
+      <button id="search-close" class="search-close" aria-label="Close search">
+        <i class="fa-solid fa-times"></i>
+      </button>
+    </div>
+
+    <div class="search-results" id="search-results">
+      <!-- Results populated by JavaScript -->
+    </div>
+
+    <div class="search-footer">
+      <div class="search-footer-left">
+        <kbd>↑</kbd>
+        <kbd>↓</kbd>
+        <span>to navigate</span>
+      </div>
+      <div class="search-footer-right">
+        <kbd>↵</kbd>
+        <span>to select</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  import Fuse from 'fuse.js';
+
+  let fuse;
+  let selectedIndex = -1;
+  let searchIndex = [];
+
+  // Fetch search index
+  async function loadSearchIndex() {
+    try {
+      const response = await fetch('/search-index.json');
+      searchIndex = await response.json();
+      initSearch();
+    } catch (error) {
+      console.error('Failed to load search index:', error);
+    }
+  }
+
+  // Initialize Fuse.js
+  function initSearch() {
+    const options = {
+      keys: [
+        { name: 'title', weight: 2 },
+        { name: 'description', weight: 1 },
+        { name: 'tags', weight: 1.5 }
+      ],
+      threshold: 0.3,
+      includeScore: true,
+      minMatchCharLength: 2
+    };
+
+    fuse = new Fuse(searchIndex, options);
+  }
+
+  // Open search modal
+  function openSearchModal() {
+    const modal = document.getElementById('search-modal');
+    const input = document.getElementById('search-input');
+
+    modal.classList.add('active');
+    document.body.style.overflow = 'hidden';
+
+    // Show recent items
+    showRecentItems();
+
+    setTimeout(() => {
+      input.focus();
+    }, 100);
+  }
+
+  // Close search modal
+  function closeSearchModal() {
+    const modal = document.getElementById('search-modal');
+    const input = document.getElementById('search-input');
+
+    modal.classList.remove('active');
+    document.body.style.overflow = '';
+    input.value = '';
+    selectedIndex = -1;
+  }
+
+  // Show recent items (first 8 items from search index)
+  function showRecentItems() {
+    const resultsContainer = document.getElementById('search-results');
+
+    if (!searchIndex || searchIndex.length === 0) {
+      resultsContainer.innerHTML = `
+        <div class="search-empty">
+          <i class="fa-solid fa-search"></i>
+          <p>Loading search index...</p>
+        </div>
+      `;
+      return;
+    }
+
+    const recentItems = searchIndex.slice(0, 8);
+
+    const resultsHTML = `
+      <div class="search-recent-header">Recent Content</div>
+      ${recentItems.map((item, index) => {
+        const isExternal = item.url.startsWith('http');
+        let pathDisplay = '';
+        if (isExternal) {
+          try {
+            const urlObj = new URL(item.url);
+            pathDisplay = urlObj.hostname + urlObj.pathname;
+          } catch {
+            pathDisplay = item.url;
+          }
+        } else {
+          pathDisplay = item.url;
+        }
+
+        return `
+          <div class="search-result-item"
+               data-index="${index}"
+               data-url="${item.url}"
+               data-external="${isExternal}">
+            <div class="search-result-path">/${item.type}${pathDisplay}</div>
+            <div class="search-result-title">${item.title}</div>
+            <div class="search-result-description">${item.description}</div>
+          </div>
+        `;
+      }).join('')}
+    `;
+
+    resultsContainer.innerHTML = resultsHTML;
+
+    // Add click handlers
+    const resultItems = resultsContainer.querySelectorAll('.search-result-item');
+    resultItems.forEach(item => {
+      item.addEventListener('click', (e) => {
+        const url = item.getAttribute('data-url');
+        const isExternal = item.getAttribute('data-external') === 'true';
+
+        if (isExternal) {
+          window.open(url, '_blank', 'noopener,noreferrer');
+        } else {
+          closeSearchModal();
+          window.location.href = url;
+        }
+      });
+    });
+  }
+
+  // Perform search
+  function performSearch(query) {
+    const resultsContainer = document.getElementById('search-results');
+
+    if (!query.trim()) {
+      showRecentItems();
+      selectedIndex = -1;
+      return;
+    }
+
+    const results = fuse.search(query);
+
+    if (results.length === 0) {
+      resultsContainer.innerHTML = `
+        <div class="search-no-results">
+          <i class="fa-solid fa-circle-exclamation"></i>
+          <p>No results found for "${query}"</p>
+        </div>
+      `;
+      selectedIndex = -1;
+      return;
+    }
+
+    // Render results
+    const resultsHTML = results.slice(0, 10).map((result, index) => {
+      const item = result.item;
+      const isExternal = item.url.startsWith('http');
+
+      // Create a clean path display
+      let pathDisplay = '';
+      if (isExternal) {
+        try {
+          const urlObj = new URL(item.url);
+          pathDisplay = urlObj.hostname + urlObj.pathname;
+        } catch {
+          pathDisplay = item.url;
+        }
+      } else {
+        pathDisplay = item.url;
+      }
+
+      return `
+        <div class="search-result-item"
+             data-index="${index}"
+             data-url="${item.url}"
+             data-external="${isExternal}">
+          <div class="search-result-path">/${item.type}${pathDisplay}</div>
+          <div class="search-result-title">${item.title}</div>
+          <div class="search-result-description">${item.description}</div>
+        </div>
+      `;
+    }).join('');
+
+    resultsContainer.innerHTML = resultsHTML;
+    selectedIndex = -1;
+
+    // Add click handlers
+    const resultItems = resultsContainer.querySelectorAll('.search-result-item');
+    resultItems.forEach(item => {
+      item.addEventListener('click', (e) => {
+        const url = item.getAttribute('data-url');
+        const isExternal = item.getAttribute('data-external') === 'true';
+
+        if (isExternal) {
+          window.open(url, '_blank', 'noopener,noreferrer');
+        } else {
+          closeSearchModal();
+          window.location.href = url;
+        }
+      });
+    });
+  }
+
+  // Keyboard navigation
+  function updateSelectedItem() {
+    const items = document.querySelectorAll('.search-result-item');
+    items.forEach((item, index) => {
+      if (index === selectedIndex) {
+        item.classList.add('active');
+        item.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      } else {
+        item.classList.remove('active');
+      }
+    });
+  }
+
+  // Initialize when DOM is ready
+  document.addEventListener('DOMContentLoaded', () => {
+    loadSearchIndex();
+
+    const searchInput = document.getElementById('search-input');
+    const searchClose = document.getElementById('search-close');
+    const searchOverlay = document.querySelector('.search-modal-overlay');
+    const searchModal = document.getElementById('search-modal');
+
+    // Search input handler
+    searchInput.addEventListener('input', (e) => {
+      performSearch(e.target.value);
+    });
+
+    // Close button handler
+    searchClose.addEventListener('click', closeSearchModal);
+
+    // Overlay click handler
+    searchOverlay.addEventListener('click', closeSearchModal);
+
+    // Keyboard shortcuts
+    document.addEventListener('keydown', (e) => {
+      // Cmd/Ctrl + K to open search
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        openSearchModal();
+        return;
+      }
+
+      // Only handle these keys when modal is open
+      if (!searchModal.classList.contains('active')) return;
+
+      // ESC to close
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        closeSearchModal();
+        return;
+      }
+
+      // Arrow key navigation
+      const items = document.querySelectorAll('.search-result-item');
+      if (items.length === 0) return;
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        selectedIndex = Math.min(selectedIndex + 1, items.length - 1);
+        updateSelectedItem();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        selectedIndex = Math.max(selectedIndex - 1, -1);
+        updateSelectedItem();
+      } else if (e.key === 'Enter' && selectedIndex >= 0) {
+        e.preventDefault();
+        items[selectedIndex].click();
+      }
+    });
+
+    // Expose function globally for navbar button
+    window.openSearchModal = openSearchModal;
+  });
+</script>

--- a/astro-site/src/layouts/Layout.astro
+++ b/astro-site/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import Navbar from '../components/Navbar.astro';
 import Footer from '../components/Footer.astro';
 import PostHog from '../components/posthog.astro';
 import DevMarketingConsole from '../components/DevMarketingConsole.astro';
+import Search from '../components/Search.astro';
 
 interface Props {
 	title: string;
@@ -69,6 +70,7 @@ const {
 		integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
 	<link rel="stylesheet" type="text/css" href="/assets/css/style.css">
 	<link rel="stylesheet" type="text/css" href="/assets/css/dark-mode.css">
+	<link rel="stylesheet" type="text/css" href="/assets/css/search.css">
 
 	{additionalCss.map(css => (
 		<link rel="stylesheet" type="text/css" href={css}>
@@ -93,14 +95,14 @@ const {
 	<script is:inline>
 		// Initialize theme before page renders to prevent flash
 		(function() {
-			const savedTheme = localStorage.getItem('theme');
+			const savedMode = localStorage.getItem('theme');
 			let theme;
 
-			if (savedTheme) {
-				// User has manually set a preference
-				theme = savedTheme;
+			if (savedMode === 'dark' || savedMode === 'light') {
+				// User has manually set dark or light
+				theme = savedMode;
 			} else {
-				// Check system preference
+				// System mode or no preference - check system preference
 				const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 				theme = prefersDark ? 'dark' : 'light';
 			}
@@ -114,6 +116,7 @@ const {
 	<slot />
 	<Footer />
 	{!hideHandbookButton && <DevMarketingConsole />}
+	<Search />
 
 	<!-- Theme Toggle Functionality -->
 	<script is:inline>
@@ -124,15 +127,32 @@ const {
 			const themeIconMobile = document.getElementById('themeIconMobile');
 			const html = document.documentElement;
 
-			// Get current theme
-			function getCurrentTheme() {
-				return html.getAttribute('data-theme') || 'dark';
+			// Get current theme mode (dark, light, or system)
+			function getCurrentMode() {
+				return localStorage.getItem('theme') || 'system';
 			}
 
-			// Update icon based on current theme
+			// Get the actual theme to display (resolves system to dark/light)
+			function getDisplayTheme() {
+				const mode = getCurrentMode();
+				if (mode === 'system') {
+					return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+				}
+				return mode;
+			}
+
+			// Update icon based on current mode
 			function updateIcon() {
-				const currentTheme = getCurrentTheme();
-				const icon = currentTheme === 'dark' ? 'fa-sun' : 'fa-moon';
+				const mode = getCurrentMode();
+				let icon;
+
+				if (mode === 'dark') {
+					icon = 'fa-moon';
+				} else if (mode === 'light') {
+					icon = 'fa-sun';
+				} else {
+					icon = 'fa-display'; // system mode
+				}
 
 				if (themeIcon) {
 					themeIcon.className = `fa-solid ${icon}`;
@@ -142,13 +162,27 @@ const {
 				}
 			}
 
-			// Toggle theme
-			function toggleTheme() {
-				const currentTheme = getCurrentTheme();
-				const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+			// Apply theme to document
+			function applyTheme() {
+				const displayTheme = getDisplayTheme();
+				html.setAttribute('data-theme', displayTheme);
+			}
 
-				html.setAttribute('data-theme', newTheme);
-				localStorage.setItem('theme', newTheme);
+			// Toggle theme: dark -> light -> system -> dark
+			function toggleTheme() {
+				const currentMode = getCurrentMode();
+				let newMode;
+
+				if (currentMode === 'dark') {
+					newMode = 'light';
+				} else if (currentMode === 'light') {
+					newMode = 'system';
+				} else {
+					newMode = 'dark';
+				}
+
+				localStorage.setItem('theme', newMode);
+				applyTheme();
 				updateIcon();
 			}
 
@@ -160,7 +194,15 @@ const {
 				themeToggleMobile.addEventListener('click', toggleTheme);
 			}
 
-			// Initialize icon
+			// Listen for system theme changes when in system mode
+			window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function() {
+				if (getCurrentMode() === 'system') {
+					applyTheme();
+				}
+			});
+
+			// Initialize
+			applyTheme();
 			updateIcon();
 		});
 	</script>

--- a/astro-site/src/lib/searchIndex.ts
+++ b/astro-site/src/lib/searchIndex.ts
@@ -1,0 +1,257 @@
+// Search index builder for Fuse.js
+import { getBlogPosts } from './notion';
+
+export interface SearchItem {
+  type: 'blog' | 'build' | 'gem' | 'website';
+  title: string;
+  description: string;
+  url: string;
+  tags?: string[];
+  date?: string;
+}
+
+export async function buildSearchIndex(): Promise<SearchItem[]> {
+  const searchIndex: SearchItem[] = [];
+
+  // Get Notion blog posts
+  const notionPosts = await getBlogPosts();
+  notionPosts.forEach(post => {
+    searchIndex.push({
+      type: 'blog',
+      title: post.title,
+      description: post.excerpt,
+      url: `/blog/${post.slug}`,
+      tags: post.tags,
+      date: post.publishedDate
+    });
+  });
+
+  // Static blog posts from blog.astro
+  const staticBlogPosts = [
+    {
+      title: "Developers love headless until they're stuck maintaining it",
+      description: "Exploring the limitations of headless CMS platforms for marketing websites and why a hybrid approach might be the better solution for team velocity and reduced complexity.",
+      url: "https://webflow.com/blog/headless-cms-developer-tradeoffs",
+      tags: ["CMS", "Headless", "DevOps"],
+      date: "Oct 8, 2025"
+    },
+    {
+      title: "MCP servers worth knowing if you're building with AI",
+      description: "Explore Model Context Protocol servers that provide structured context for AI tools. Learn about integrating MCP servers like Context7, Figma, GitHub, and more with AI-powered development environments.",
+      url: "https://webflow.com/blog/ai-mcp-servers",
+      tags: ["AI", "MCP", "Development"],
+      date: "Aug 13, 2025"
+    }
+  ];
+
+  staticBlogPosts.forEach(post => {
+    searchIndex.push({
+      type: 'blog',
+      title: post.title,
+      description: post.description,
+      url: post.url,
+      tags: post.tags,
+      date: post.date
+    });
+  });
+
+  // Builds from builds.astro
+  const builds = [
+    {
+      title: "Fantasy Football Legend",
+      description: "A showcase website for a Fantasy Football League built with HTML, CSS, and JavaScript.",
+      url: "https://stahlwalker.github.io/fantasyfootball/",
+      tags: ["HTML", "CSS", "JavaScript"]
+    },
+    {
+      title: "SERP Tracker",
+      description: "Real-time search engine ranking tracker built with React and TypeScript. Features Chart.js visualizations, TanStack Table for data display, and SERP API integration.",
+      url: "https://seo-rank-tracker-iota.vercel.app/",
+      tags: ["React", "TypeScript", "Chart.js", "Tailwind CSS"]
+    },
+    {
+      title: "Stahlwalker Cookbook",
+      description: "Full-stack recipe app with Next.js and Contentful CMS featuring JAMstack architecture and dynamic content delivery.",
+      url: "https://cookblog.vercel.app/",
+      tags: ["Next.js", "React", "Contentful"]
+    },
+    {
+      title: "Shacks Bloom & Co",
+      description: "Modern web application built with React and Vite featuring fast build times and optimized performance.",
+      url: "https://bloom-ebon-two.vercel.app/",
+      tags: ["React", "Vite", "JavaScript"]
+    },
+    {
+      title: "Developer Hub",
+      description: "Modern developer portal built with Vite, React, and TypeScript. Features Framer Motion animations, Tailwind CSS styling, and syntax highlighting with Prism.",
+      url: "https://developer-hub-webflow.vercel.app/",
+      tags: ["Vite", "React", "TypeScript", "Tailwind CSS"]
+    },
+    {
+      title: "Packers Nation Invasion",
+      description: "A site dedicated to tracking away games for the Green Bay Packers. Site created using Materialize CSS.",
+      url: "https://stahlwalker.github.io/greenbaypackers/",
+      tags: ["Materialize", "CSS", "Portfolio"]
+    },
+    {
+      title: "Stahlwalker.org",
+      description: "My first portfolio site built with Jekyll, a static site generator. Features a clean design with blog integration and project showcase.",
+      url: "https://stahlwalker.org/",
+      tags: ["Jekyll", "Ruby", "Portfolio"]
+    },
+    {
+      title: "Portfolio Template",
+      description: "Single page portfolio template created using Materialize CSS. A clean, responsive design showcasing work and skills.",
+      url: "https://stahlwalker.github.io/materialize/",
+      tags: ["Materialize", "CSS", "Template"]
+    }
+  ];
+
+  builds.forEach(build => {
+    searchIndex.push({
+      type: 'build',
+      title: build.title,
+      description: build.description,
+      url: build.url,
+      tags: build.tags
+    });
+  });
+
+  // Gems from gems.astro
+  const gems = [
+    {
+      title: "Developer-Led Links Repository",
+      description: "The ultimate curated repository of developer marketing and developer relations resources. Includes comprehensive collections of blogs, talks, podcasts, books, newsletters, and communities—everything you need to level up your developer marketing game.",
+      url: "https://github.com/developer-led/links",
+      tags: ["Featured", "Resources"]
+    },
+    {
+      title: "DevToolJobs",
+      description: "A focused job board for GTM roles at developer tooling companies. Find marketing, sales, and community positions at the intersection of developer tools and go-to-market strategy.",
+      url: "https://devtooljobs.com/",
+      tags: ["Jobs", "Career"]
+    },
+    {
+      title: "Developer Marketing Slack Community",
+      description: "Active Slack community for developer marketing professionals. Connect with peers, share strategies, and discuss best practices for marketing to developers.",
+      url: "https://marketingto.dev/",
+      tags: ["Community", "Slack"]
+    },
+    {
+      title: "Frontend Developer Roadmap",
+      description: "Step by step guide to becoming a modern frontend developer in 2025. Covers HTML, CSS, JavaScript, frameworks, and essential skills for web development.",
+      url: "https://roadmap.sh/frontend",
+      tags: ["Learning", "Roadmap"]
+    },
+    {
+      title: "Plug - Developer Influencer Marketing",
+      description: "Platform connecting developer tools with technical influencers. Amplify your product through authentic developer voices and community engagement.",
+      url: "https://plug.dev/",
+      tags: ["Marketing", "Influencer"]
+    },
+    {
+      title: "How to Spend Your Marketing Budget",
+      description: "PostHog's guide on allocating marketing budget for developer tools. Real insights on what works and what doesn't when marketing to developers.",
+      url: "https://posthog.com/founders/actual-marketing-budget",
+      tags: ["Strategy", "Budget"]
+    },
+    {
+      title: "Dev.Events - Developer Conferences",
+      description: "Comprehensive listing of 1,151+ developer conferences worldwide for 2025/2026. Filter by technology, region, or topic to find the perfect events for your community.",
+      url: "https://dev.events/",
+      tags: ["Events", "Conferences"]
+    },
+    {
+      title: "Markepear - Dev Tool Marketing Examples",
+      description: "Collection of the best developer tool marketing campaigns, designs, and copy. Features landing pages, social posts, product tours, and creative positioning strategies.",
+      url: "https://www.markepear.dev/examples",
+      tags: ["Examples", "Inspiration"]
+    },
+    {
+      title: "Stytch's Out-of-Home Campaign",
+      description: "Behind-the-scenes look at how Stytch executed an impressive outdoor advertising campaign. Learn their strategy, execution, and results from going big with OOH.",
+      url: "https://stytch.com/blog/the-making-of-an-ooh-campaign/",
+      tags: ["Case Study", "OOH"]
+    },
+    {
+      title: "DevRel Careers",
+      description: "Job board for Developer Relations and Developer Marketing roles. Find opportunities in developer advocacy, community management, and technical marketing.",
+      url: "https://devrelcareers.com/",
+      tags: ["Careers", "Jobs"]
+    },
+    {
+      title: "Stefan Judis - DevRel Contractor",
+      description: "Stefan Judis is a developer advocate and independent contractor who runs Web Weekly, a curated newsletter covering web platform updates, browser changes, and tools for modern developers.",
+      url: "https://www.stefanjudis.com/",
+      tags: ["DevRel", "Newsletter"]
+    },
+    {
+      title: "Brand Over Matter",
+      description: "Brand agency specializing in creating impactful brand identities and experiences. Helping companies stand out with creative design and strategic branding expertise.",
+      url: "https://brandovermatter.com/",
+      tags: ["Design", "Branding"]
+    },
+    {
+      title: "Wappalyzer - Technology Profiler",
+      description: "Discover what technologies websites are built with. Identify CMS, frameworks, analytics tools, and tech stacks for competitive research and lead generation.",
+      url: "https://www.wappalyzer.com/",
+      tags: ["Tools", "Research"]
+    },
+    {
+      title: "Carbon - Code Snippet Tool",
+      description: "Create and share beautiful images of your source code. Perfect for social media posts, documentation, and presentations with customizable themes and syntax highlighting.",
+      url: "https://carbon.now.sh/",
+      tags: ["Tools", "Design"]
+    }
+  ];
+
+  gems.forEach(gem => {
+    searchIndex.push({
+      type: 'gem',
+      title: gem.title,
+      description: gem.description,
+      url: gem.url,
+      tags: gem.tags
+    });
+  });
+
+  // Fancy websites from gems.astro
+  const websites = [
+    {
+      title: "PostHog",
+      description: "Product analytics platform with great website design",
+      url: "https://posthog.com/",
+      tags: ["Platform"]
+    },
+    {
+      title: "Stripe Developers",
+      description: "Stripe's developer hub with excellent documentation design",
+      url: "https://stripe.dev/",
+      tags: ["Dev Hub"]
+    },
+    {
+      title: "Cloudflare Sandbox",
+      description: "Cloudflare's interactive sandbox platform",
+      url: "https://sandbox.cloudflare.com/",
+      tags: ["Platform"]
+    },
+    {
+      title: "GitHub",
+      description: "GitHub's platform and website design",
+      url: "https://github.com/home",
+      tags: ["Platform"]
+    }
+  ];
+
+  websites.forEach(website => {
+    searchIndex.push({
+      type: 'website',
+      title: website.title,
+      description: website.description,
+      url: website.url,
+      tags: website.tags
+    });
+  });
+
+  return searchIndex;
+}

--- a/astro-site/src/pages/search-index.json.ts
+++ b/astro-site/src/pages/search-index.json.ts
@@ -1,0 +1,13 @@
+import type { APIContext } from 'astro';
+import { buildSearchIndex } from '../lib/searchIndex';
+
+export async function GET(context: APIContext) {
+  const searchIndex = await buildSearchIndex();
+
+  return new Response(JSON.stringify(searchIndex), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  });
+}


### PR DESCRIPTION
- Implement client-side search using Fuse.js with fuzzy matching across blogs, builds, gems, and websites
- Add terminal-inspired search modal with macOS window controls and monospace typography
- Create search index builder that aggregates all site content types
- Update navbar with search button (⌘K keyboard shortcut)
- Enhance theme toggle to cycle between dark, light, and system modes
- Add search footer with keyboard navigation hints (arrow keys, enter to select)
- Show recent content when search is empty to aid discovery
- Style search modal with lime/yellow-green accents matching site branding
- Ensure proper theme toggle alignment with search icon in navbar
- Support automatic theme switching when in system mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)