### PR TITLE
Update dark mode to navy blue with consistent grid pattern

### DIFF
--- a/astro-site/DARK_MODE_COLOR_REFERENCE.md
+++ b/astro-site/DARK_MODE_COLOR_REFERENCE.md
@@ -1,0 +1,67 @@
+# Dark Mode Color Reference
+
+This file contains the original midnight blue dark mode color scheme for reference.
+
+## Original Midnight Blue Colors
+
+These were the original dark mode colors before switching to the navy blue variant:
+
+```css
+:root {
+    /* Dark mode colors (default) - Original Midnight Blue */
+    --bg-primary: #0a0e27;
+    --bg-secondary: #151932;
+    --bg-tertiary: #1e2442;
+    --text-primary: #e4e4e7;
+    --text-secondary: #a1a1aa;
+    --accent-primary: #60a5fa;
+    --accent-secondary: #818cf8;
+    --accent-yellow: #fbbf24;
+    --accent-green: #34d399;
+    --accent-blue: #60a5fa;
+    --accent-purple: #a855f7;
+    --code-keyword: #c792ea;
+    --code-string: #c3e88d;
+    --code-property: #82aaff;
+    --code-comment: #697098;
+}
+```
+
+## Current Navy Blue Colors
+
+The current dark mode colors (as of December 6, 2025):
+
+```css
+:root {
+    /* Dark mode colors (default) - Navy blue */
+    --bg-primary: #0a1128;
+    --bg-secondary: #0f1a35;
+    --bg-tertiary: #162544;
+    --text-primary: #e4e4e7;
+    --text-secondary: #a1a1aa;
+    --accent-primary: #60a5fa;
+    --accent-secondary: #818cf8;
+    --accent-yellow: #fbbf24;
+    --accent-green: #34d399;
+    --accent-blue: #60a5fa;
+    --accent-purple: #a855f7;
+    --code-keyword: #c792ea;
+    --code-string: #c3e88d;
+    --code-property: #82aaff;
+    --code-comment: #697098;
+}
+```
+
+## Differences
+
+The main differences are in the background colors:
+- `--bg-primary`: `#0a0e27` → `#0a1128` (more blue, less purple)
+- `--bg-secondary`: `#151932` → `#0f1a35` (darker, more blue)
+- `--bg-tertiary`: `#1e2442` → `#162544` (more saturated blue)
+
+All other colors (text, accents, code highlighting) remain the same.
+
+## Location
+
+The dark mode colors are defined in:
+`/astro-site/public/assets/css/dark-mode.css`

--- a/astro-site/public/assets/css/about.css
+++ b/astro-site/public/assets/css/about.css
@@ -2,7 +2,7 @@
 
 /* About Hero Section */
 .about-hero {
-    background: var(--bg-primary);
+    background: transparent;
     padding: 6rem 2rem 3rem;
     text-align: center;
 }
@@ -26,7 +26,7 @@
 
 /* About Section */
 .about-section {
-    background: var(--bg-primary);
+    background: transparent;
     padding: 2rem 2rem 4rem;
 }
 

--- a/astro-site/public/assets/css/blog.css
+++ b/astro-site/public/assets/css/blog.css
@@ -2,7 +2,7 @@
 
 /* Blog Hero Section */
 .blog-hero {
-    background: var(--bg-primary);
+    background: transparent;
     padding: 6rem 2rem 3rem;
     text-align: center;
 }
@@ -26,7 +26,7 @@
 
 /* Blog Feed Section */
 .blog-feed-section {
-    background: var(--bg-primary);
+    background: transparent;
     padding: 2rem 2rem 4rem;
 }
 
@@ -81,7 +81,7 @@
 
 /* Add background to compact post cards */
 .blog-card-compact {
-    background: rgba(255, 255, 255, 0.05) !important;
+    background: var(--bg-secondary) !important;
     border: 1px solid rgba(255, 255, 255, 0.1) !important;
     border-radius: 8px !important;
     padding: 0 1rem !important;
@@ -93,7 +93,7 @@
 }
 
 .blog-card-compact:hover {
-    background: rgba(255, 255, 255, 0.08) !important;
+    background: var(--bg-tertiary) !important;
     border-color: rgba(96, 165, 250, 0.4) !important;
     transform: translateX(4px);
 }
@@ -115,16 +115,16 @@
 
 /* Compact Blog Card (no thumbnail) */
 .blog-card-compact {
-    background: transparent;
-    border: none;
+    background: var(--bg-secondary);
+    border: 1px solid rgba(255, 255, 255, 0.1);
     border-bottom: 1px solid rgba(255, 255, 255, 0.05);
-    border-radius: 0;
+    border-radius: 8px;
 }
 
 .blog-card-compact:hover {
-    background: rgba(255, 255, 255, 0.02);
-    border-color: rgba(255, 255, 255, 0.05);
-    transform: none;
+    background: var(--bg-tertiary);
+    border-color: rgba(96, 165, 250, 0.4);
+    transform: translateX(4px);
     box-shadow: none;
 }
 

--- a/astro-site/public/assets/css/builds.css
+++ b/astro-site/public/assets/css/builds.css
@@ -6,7 +6,7 @@
     margin: 4rem auto 0;
     padding: 3rem 2rem;
     border-top: 2px solid rgba(96, 165, 250, 0.3);
-    background: linear-gradient(135deg, rgba(96, 165, 250, 0.02), rgba(129, 140, 248, 0.02));
+    background: var(--bg-secondary);
     border-radius: 12px;
     position: relative;
 }
@@ -177,7 +177,7 @@
 /* Light mode styles for early projects */
 [data-theme="light"] .early-projects-section {
     border-top-color: rgba(37, 99, 235, 0.5);
-    background: linear-gradient(135deg, rgba(37, 99, 235, 0.02), rgba(99, 102, 241, 0.02));
+    background: var(--bg-secondary);
 }
 
 [data-theme="light"] .early-projects-section .section-label {
@@ -401,7 +401,7 @@
 
 /* Builds Hero Section */
 .builds-hero {
-    background: var(--bg-primary);
+    background: transparent;
     padding: 6rem 2rem 3rem;
     text-align: center;
 }
@@ -425,7 +425,7 @@
 
 /* Builds Section */
 .builds-section {
-    background: var(--bg-primary);
+    background: transparent;
     padding: 2rem 2rem 4rem;
 }
 

--- a/astro-site/public/assets/css/dark-mode.css
+++ b/astro-site/public/assets/css/dark-mode.css
@@ -1,10 +1,10 @@
 /* Dark Mode Developer-Focused Design */
 
 :root {
-    /* Dark mode colors (default) */
-    --bg-primary: #0a0e27;
-    --bg-secondary: #151932;
-    --bg-tertiary: #1e2442;
+    /* Dark mode colors (default) - Navy blue */
+    --bg-primary: #0a1128;
+    --bg-secondary: #0f1a35;
+    --bg-tertiary: #162544;
     --text-primary: #e4e4e7;
     --text-secondary: #a1a1aa;
     --accent-primary: #60a5fa;
@@ -45,7 +45,12 @@
 }
 
 body {
-    background: var(--bg-primary);
+    background-color: var(--bg-primary);
+    background-image:
+        linear-gradient(rgba(255, 255, 255, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+    background-size: 24px 24px;
+    background-position: -1px -1px;
     color: var(--text-primary);
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     line-height: 1.6;
@@ -200,13 +205,13 @@ body {
     background-image:
         linear-gradient(rgba(255, 255, 255, 0.03) 1px, transparent 1px),
         linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
-    background-size: 50px 50px;
+    background-size: 24px 24px;
     animation: gridMove 20s linear infinite;
 }
 
 @keyframes gridMove {
     0% { transform: translate(0, 0); }
-    100% { transform: translate(50px, 50px); }
+    100% { transform: translate(24px, 24px); }
 }
 
 .hero-container {
@@ -556,7 +561,7 @@ body {
 
 /* Featured Content Section */
 .featured-content {
-    background: var(--bg-primary);
+    background: transparent;
     padding: 4rem 2rem;
     position: relative;
 }

--- a/astro-site/public/assets/css/gems.css
+++ b/astro-site/public/assets/css/gems.css
@@ -828,7 +828,7 @@ html {
 .websites-table {
     max-width: 600px;
     margin: 0 auto;
-    background: linear-gradient(135deg, rgba(96, 165, 250, 0.03), rgba(168, 85, 247, 0.03));
+    background: var(--bg-secondary);
     border: 1px solid rgba(96, 165, 250, 0.3);
     border-radius: 12px;
     overflow: hidden;

--- a/astro-site/src/pages/handbook.astro
+++ b/astro-site/src/pages/handbook.astro
@@ -199,6 +199,12 @@ import Layout from '../layouts/Layout.astro';
 </Layout>
 
 <style>
+	/* Override body grid background for handbook page only */
+	:global(body) {
+		background-color: #1a1a1a !important;
+		background-image: none !important;
+	}
+
 	.handbook-page-container {
 		min-height: 100vh;
 		background: #1a1a1a;
@@ -242,6 +248,7 @@ import Layout from '../layouts/Layout.astro';
 		grid-template-columns: 240px 1fr;
 		max-width: 1200px;
 		margin: 0 auto;
+		min-height: 100vh;
 	}
 
 	.handbook-page-nav {
@@ -660,6 +667,11 @@ import Layout from '../layouts/Layout.astro';
 	}
 
 	/* Light Mode Styles for Handbook Page */
+	:global([data-theme="light"]) body {
+		background-color: #f8fafc !important;
+		background-image: none !important;
+	}
+
 	:global([data-theme="light"]) .handbook-page-container {
 		background: var(--bg-secondary);
 	}


### PR DESCRIPTION
- Changed dark mode background colors to navy blue theme
- Added 24px checkered grid pattern across entire site in dark mode
- Made grid consistent on all pages (home, blog, about, builds, gems)
- Added solid backgrounds to content sections for better readability:
  - Early projects section on builds page
  - Compact blog posts
  - Websites table on gems page
- Fixed handbook page to maintain solid backgrounds without grid
- Added DARK_MODE_COLOR_REFERENCE.md to preserve original midnight blue colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)