### PR TITLE
Update IndexNow configuration for lukestahl.io

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,19 +61,19 @@ jobs:
           curl -X POST "https://api.indexnow.org/indexnow" \
             -H "Content-Type: application/json" \
             -d '{
-              "host": "lucasstahl.com",
-              "key": "b6bz6by4n4xv6srpxp7p84hkq1uxq12y",
-              "keyLocation": "https://lucasstahl.com/b6bz6by4n4xv6srpxp7p84hkq1uxq12y.txt",
+              "host": "lukestahl.io",
+              "key": "8rencvayba2db8knz7h2zgkc5pg4jfgw",
+              "keyLocation": "https://lukestahl.io/8rencvayba2db8knz7h2zgkc5pg4jfgw.txt",
               "urlList": [
-                "https://lucasstahl.com/",
-                "https://lucasstahl.com/about/",
-                "https://lucasstahl.com/blog/",
-                "https://lucasstahl.com/builds/",
-                "https://lucasstahl.com/gems/",
-                "https://lucasstahl.com/handbook/",
-                "https://lucasstahl.com/status/",
-                "https://lucasstahl.com/dev-marketing-cheat-sheet/",
-                "https://lucasstahl.com/blog/my-stack/",
-                "https://lucasstahl.com/blog/markdown-vs-cms/"
+                "https://lukestahl.io/",
+                "https://lukestahl.io/about/",
+                "https://lukestahl.io/blog/",
+                "https://lukestahl.io/builds/",
+                "https://lukestahl.io/gems/",
+                "https://lukestahl.io/handbook/",
+                "https://lukestahl.io/status/",
+                "https://lukestahl.io/dev-marketing-cheat-sheet/",
+                "https://lukestahl.io/blog/my-stack/",
+                "https://lukestahl.io/blog/markdown-vs-cms/"
               ]
             }'

--- a/astro-site/public/8rencvayba2db8knz7h2zgkc5pg4jfgw.txt
+++ b/astro-site/public/8rencvayba2db8knz7h2zgkc5pg4jfgw.txt
@@ -1,0 +1,1 @@
+8rencvayba2db8knz7h2zgkc5pg4jfgw

--- a/astro-site/public/b6bz6by4n4xv6srpxp7p84hkq1uxq12y.txt
+++ b/astro-site/public/b6bz6by4n4xv6srpxp7p84hkq1uxq12y.txt
@@ -1,1 +1,0 @@
-b6bz6by4n4xv6srpxp7p84hkq1uxq12y


### PR DESCRIPTION
- Add new IndexNow API key file for lukestahl.io domain
- Update deploy workflow with new key: 8rencvayba2db8knz7h2zgkc5pg4jfgw
- Update all IndexNow URLs from lucasstahl.com to lukestahl.io
- Remove old lucasstahl.com key file

This ensures search engines are notified immediately when content is updated on the new lukestahl.io domain.

🤖 Generated with Claude Code