### PR TITLE
Fix MinimalLayout OG tags to use lukestahl.io

### DIFF
--- a/astro-site/src/layouts/MinimalLayout.astro
+++ b/astro-site/src/layouts/MinimalLayout.astro
@@ -11,8 +11,8 @@ interface Props {
 const {
 	title,
 	description = "Developer Marketing Cheat Sheet - A comprehensive guide to developer marketing practices, metrics, and resources.",
-	canonicalUrl = "https://lucasstahl.com/dev-marketing-cheat-sheet",
-	ogImage = "https://lucasstahl.com/assets/images/Hero_OG.png"
+	canonicalUrl = "https://lukestahl.io/dev-marketing-cheat-sheet",
+	ogImage = "https://lukestahl.io/assets/images/Hero_OG.png"
 } = Astro.props;
 ---
 


### PR DESCRIPTION
- Update default canonicalUrl from lucasstahl.com to lukestahl.io
- Update default ogImage URL to use lukestahl.io domain
- Ensures Open Graph and Twitter Card tags use correct domain

🤖 Generated with Claude Code