### PR TITLE
Eliminate white flash on page navigation without View Transitions

### DIFF
--- a/astro-site/src/layouts/Layout.astro
+++ b/astro-site/src/layouts/Layout.astro
@@ -151,8 +151,27 @@ const {
 			}
 
 			document.documentElement.setAttribute('data-theme', theme);
+
+			// Set background color immediately to prevent white flash
+			const backgroundColor = theme === 'dark' ? '#0a0e27' : '#f8fafc';
+			document.documentElement.style.backgroundColor = backgroundColor;
 		})();
 	</script>
+
+	<!-- Eliminate white flash on page navigation -->
+	<style is:global>
+		html {
+			background-color: #0a0e27; /* Fallback for dark mode */
+		}
+
+		[data-theme="light"] {
+			background-color: #f8fafc;
+		}
+
+		body {
+			background-color: transparent;
+		}
+	</style>
 </head>
 <body>
 	{showAnnouncement && announcementMessage && (


### PR DESCRIPTION
Added background color that matches theme to prevent white flash:
- Sets html background to match current theme (dark/light)
- Inline JavaScript sets background immediately before render
- No performance impact or navigation delay
- Works seamlessly with existing theme toggle

Background colors:
- Dark mode: #0a0e27
- Light mode: #f8fafc

Decided against View Transitions after testing - they add perceived delay even on static pages. This solution keeps fast navigation while eliminating visual flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)