### PR TITLE
Adjust performance strategy: only defer Google Fonts

### DIFF
--- a/astro-site/src/layouts/Layout.astro
+++ b/astro-site/src/layouts/Layout.astro
@@ -112,13 +112,8 @@ const {
 	<link rel="preconnect" href="https://us-i.posthog.com">
 	<link rel="preconnect" href="https://maxcdn.bootstrapcdn.com">
 
-	<!-- Async load Bootstrap to prevent render blocking -->
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
-		integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous" media="print" onload="this.media='all'">
-	<noscript>
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
-			integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
-	</noscript>
+		integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
 	<link rel="stylesheet" type="text/css" href="/assets/css/style.css">
 	<link rel="stylesheet" type="text/css" href="/assets/css/dark-mode.css">
 	<link rel="stylesheet" type="text/css" href="/assets/css/search.css">
@@ -132,13 +127,13 @@ const {
 	<link href="https://fonts.googleapis.com/css?family=Gruppo&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
 	<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
 
-	<!-- Async load Font Awesome to prevent render blocking -->
-	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" media="print" onload="this.media='all'">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+
+	<!-- Noscript fallback for fonts -->
 	<noscript>
 		<link href="https://fonts.googleapis.com/css?family=Share+Tech&display=swap" rel="stylesheet">
 		<link href="https://fonts.googleapis.com/css?family=Gruppo&display=swap" rel="stylesheet">
 		<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 	</noscript>
 
 	<!-- favicon -->


### PR DESCRIPTION
Reverted Bootstrap and Font Awesome to render-blocking based on testing. Deferring critical layout CSS caused worse FOUC than original blocking.

Strategy now:
- Google Fonts: Deferred (saves ~2.3s mobile, minimal visual impact)
- Bootstrap/Font Awesome: Render-blocking (needed for immediate layout)
- Local CSS: Render-blocking (small, fast, critical)

This conservative approach prioritizes stable scores over aggressive optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)